### PR TITLE
Remove spiflash from siracusa

### DIFF
--- a/pulp/chips/siracusa/pulp_open_board.py
+++ b/pulp/chips/siracusa/pulp_open_board.py
@@ -17,8 +17,6 @@
 import gvsoc.systree as st
 from pulp.chips.siracusa.pulp_open import Pulp_open
 from devices.hyperbus.hyperflash import Hyperflash
-from devices.spiflash.spiflash import Spiflash
-from devices.spiflash.atxp032 import Atxp032
 from devices.hyperbus.hyperram import Hyperram
 from devices.testbench.testbench import Testbench
 from devices.uart.uart_checker import Uart_checker
@@ -37,16 +35,7 @@ class Pulp_open_board(st.Component):
 
         # Flash
         hyperflash = Hyperflash(self, 'hyperflash')
-        spiflash = Spiflash(self, 'spiflash')
         hyperram = Hyperram(self, 'ram')
-
-        self.register_flash(
-            DefaultFlashRomV2(self, 'flash', image_name=spiflash.get_image_path(),
-                flash_attributes={
-                    "flash_type": 'spi'
-                },
-                size=8*1024*1024
-            ))
 
         self.register_flash(
             DefaultFlashRomV2(self, 'hyperflash', image_name=hyperflash.get_image_path(),
@@ -55,9 +44,6 @@ class Pulp_open_board(st.Component):
                 },
                 size=8*1024*1024
             ))
-
-        self.bind(pulp, 'spim0_cs0', spiflash, 'cs')
-        self.bind(pulp, 'spim0_cs0_data', spiflash, 'input')
 
         self.bind(pulp, 'hyper0_cs1_data', hyperflash, 'input')
 


### PR DESCRIPTION
Gvsoc complains that there is no `spiflash.bin` when running an application compiled for Siracusa.
The actual board doesn't have an SPI flash so I removed it from the Siracusa gvsoc model.