### PR TITLE
siracusa: integrate Light_RedMulE accelerator

### DIFF
--- a/pulp/chips/siracusa/cluster.json
+++ b/pulp/chips/siracusa/cluster.json
@@ -178,6 +178,22 @@
             }
         },
 
+        "redmule": {
+            "mapping": {
+                "base": "0x10201C00",
+                "size": "0x00000200",
+                "remove_offset": "0x10201C00"
+            },
+            "tcdm_bank_width": 4,
+            "tcdm_bank_number": 16,
+            "elem_size": 4,
+            "ce_height": 12,
+            "ce_width": 4,
+            "ce_pipe": 3,
+            "queue_depth": 8,
+            "fold_tiles_mapping": 0
+        },
+
         "dbg_unit": {
             "base": "0x10300000",
             "size"  : "0x00008000"

--- a/pulp/chips/siracusa/cluster.json
+++ b/pulp/chips/siracusa/cluster.json
@@ -1,5 +1,7 @@
 
 {
+    "accelerator": "neureka",
+
     "alias": "0x00000000",
     "mapping": {
         "base": "0x10000000",

--- a/pulp/chips/siracusa/cluster.py
+++ b/pulp/chips/siracusa/cluster.py
@@ -62,7 +62,7 @@ class Cluster(st.Component):
 
     """
 
-    def __init__(self, parent, name, config_file, cid: int=0):
+    def __init__(self, parent, name, config_file, cid: int=0, accelerator: str=None):
         super(Cluster, self).__init__(parent, name)
 
         #
@@ -70,6 +70,16 @@ class Cluster(st.Component):
         #
 
         self.add_properties(self.load_property_file(config_file))
+
+        # Accelerator variant — 'neureka' (default) or 'redmule'.
+        # Neureka and Light_RedMulE share the L1 `neureka_in` TCDM port, so
+        # the cluster must pick exactly one. The constructor kwarg, if
+        # provided, overrides the `accelerator` key in cluster.json.
+        if accelerator is None:
+            accelerator = self.get_property('accelerator') or 'neureka'
+        if accelerator not in ('neureka', 'redmule'):
+            raise ValueError(f"accelerator must be 'neureka' or 'redmule', got {accelerator!r}")
+        self.accelerator = accelerator
 
         nb_pe               = self.get_property('nb_pe', int)
         cluster_size        = self.get_property('mapping/size', int)
@@ -121,23 +131,25 @@ class Cluster(st.Component):
         # Cluster control
         cluster_control = Cluster_control(self, 'cluster_ctrl', nb_core=nb_pe)
 
-        # NEUREKA
-        neureka = Neureka(self, 'neureka')
-
-        # Light_RedMulE
-        redmule_config = self.get_property('peripherals/redmule')
-        redmule = LightRedmule(
-            self,
-            'redmule',
-            tcdm_bank_width    = redmule_config.get('tcdm_bank_width', 4),
-            tcdm_bank_number   = redmule_config.get('tcdm_bank_number', 16),
-            elem_size          = redmule_config.get('elem_size', 4),
-            ce_height          = redmule_config.get('ce_height', 12),
-            ce_width           = redmule_config.get('ce_width', 4),
-            ce_pipe            = redmule_config.get('ce_pipe', 3),
-            queue_depth        = redmule_config.get('queue_depth', 8),
-            fold_tiles_mapping = redmule_config.get('fold_tiles_mapping', 0),
-        )
+        # Accelerator — Neureka or Light_RedMulE, mutually exclusive
+        neureka = None
+        redmule = None
+        if self.accelerator == 'neureka':
+            neureka = Neureka(self, 'neureka')
+        else:
+            redmule_config = self.get_property('peripherals/redmule')
+            redmule = LightRedmule(
+                self,
+                'redmule',
+                tcdm_bank_width    = redmule_config.get('tcdm_bank_width', 4),
+                tcdm_bank_number   = redmule_config.get('tcdm_bank_number', 16),
+                elem_size          = redmule_config.get('elem_size', 4),
+                ce_height          = redmule_config.get('ce_height', 12),
+                ce_width           = redmule_config.get('ce_width', 4),
+                ce_pipe            = redmule_config.get('ce_pipe', 3),
+                queue_depth        = redmule_config.get('queue_depth', 8),
+                fold_tiles_mapping = redmule_config.get('fold_tiles_mapping', 0),
+            )
 
         # Icache controller
         icache_ctrl = Icache_ctrl(self, 'icache_ctrl')
@@ -160,7 +172,8 @@ class Cluster(st.Component):
         self.bind(l1, 'cluster_ico', cluster_ico, 'input')
 
         # Wmem
-        self.bind(neureka, 'wmem_out', wmem, 'input')
+        if neureka is not None:
+            self.bind(neureka, 'wmem_out', wmem, 'input')
 
         # Cores
         for i in range(0, nb_pe):
@@ -226,13 +239,14 @@ class Cluster(st.Component):
         periph_ico.add_mapping('dma', **self._reloc_mapping(self.get_property('peripherals/dma/mapping')))
         self.bind(periph_ico, 'dma', mchan, 'in_%d' % nb_pe)
 
-        periph_ico.add_mapping('neureka', **self._reloc_mapping(self.get_property('peripherals/neureka/mapping')))
-        self.bind(periph_ico, 'neureka', neureka, 'input')
-
-        # Light_RedMulE bindings (uses TCDM port shared with Neureka)
-        periph_ico.add_mapping('redmule', **self._reloc_mapping(self.get_property('peripherals/redmule/mapping')))
-        self.bind(periph_ico, 'redmule', redmule, 'input')
-        self.bind(redmule, 'tcdm', l1, 'neureka_in')
+        if neureka is not None:
+            periph_ico.add_mapping('neureka', **self._reloc_mapping(self.get_property('peripherals/neureka/mapping')))
+            self.bind(periph_ico, 'neureka', neureka, 'input')
+        else:
+            # Light_RedMulE takes the L1 `neureka_in` TCDM slot.
+            periph_ico.add_mapping('redmule', **self._reloc_mapping(self.get_property('peripherals/redmule/mapping')))
+            self.bind(periph_ico, 'redmule', redmule, 'input')
+            self.bind(redmule, 'tcdm', l1, 'neureka_in')
 
         # MCHAN
         self.bind(mchan, 'ext_irq_itf', self, 'dma_irq')
@@ -260,10 +274,11 @@ class Cluster(st.Component):
             self.bind(pes[i], 'halt_status', cluster_control, 'core_halt_%d' % i)
 
         # NEUREKA
-        for i in range(0, nb_pe):
-            self.bind(neureka, 'irq', event_unit, 'in_event_%d_pe_%d' % (neureka_irq, i))
+        if neureka is not None:
+            for i in range(0, nb_pe):
+                self.bind(neureka, 'irq', event_unit, 'in_event_%d_pe_%d' % (neureka_irq, i))
 
-        self.bind(neureka, 'out', l1, 'neureka_in')
+            self.bind(neureka, 'out', l1, 'neureka_in')
 
         # Icache controller
         self.bind(icache_ctrl, 'enable', icache, 'enable')

--- a/pulp/chips/siracusa/cluster.py
+++ b/pulp/chips/siracusa/cluster.py
@@ -25,6 +25,7 @@ from pulp.mchan.mchan_v7 import Mchan
 from pulp.timer.timer_v2 import Timer
 from pulp.cluster.cluster_control_v2 import Cluster_control
 from pulp.neureka.neureka import Neureka
+from pulp.light_redmule.light_redmule import LightRedmule
 from pulp.icache_ctrl.icache_ctrl_v2 import Icache_ctrl
 
 
@@ -123,6 +124,21 @@ class Cluster(st.Component):
         # NEUREKA
         neureka = Neureka(self, 'neureka')
 
+        # Light_RedMulE
+        redmule_config = self.get_property('peripherals/redmule')
+        redmule = LightRedmule(
+            self,
+            'redmule',
+            tcdm_bank_width    = redmule_config.get('tcdm_bank_width', 4),
+            tcdm_bank_number   = redmule_config.get('tcdm_bank_number', 16),
+            elem_size          = redmule_config.get('elem_size', 4),
+            ce_height          = redmule_config.get('ce_height', 12),
+            ce_width           = redmule_config.get('ce_width', 4),
+            ce_pipe            = redmule_config.get('ce_pipe', 3),
+            queue_depth        = redmule_config.get('queue_depth', 8),
+            fold_tiles_mapping = redmule_config.get('fold_tiles_mapping', 0),
+        )
+
         # Icache controller
         icache_ctrl = Icache_ctrl(self, 'icache_ctrl')
 
@@ -212,6 +228,11 @@ class Cluster(st.Component):
 
         periph_ico.add_mapping('neureka', **self._reloc_mapping(self.get_property('peripherals/neureka/mapping')))
         self.bind(periph_ico, 'neureka', neureka, 'input')
+
+        # Light_RedMulE bindings (uses TCDM port shared with Neureka)
+        periph_ico.add_mapping('redmule', **self._reloc_mapping(self.get_property('peripherals/redmule/mapping')))
+        self.bind(periph_ico, 'redmule', redmule, 'input')
+        self.bind(redmule, 'tcdm', l1, 'neureka_in')
 
         # MCHAN
         self.bind(mchan, 'ext_irq_itf', self, 'dma_irq')

--- a/pulp/chips/siracusa/pulp_open.py
+++ b/pulp/chips/siracusa/pulp_open.py
@@ -24,7 +24,7 @@ import interco.router_proxy as router_proxy
 
 class Pulp_open(st.Component):
 
-    def __init__(self, parent, name, parser, soc_config_file='pulp/chips/siracusa/soc.json', cluster_config_file='pulp/chips/siracusa/cluster.json', padframe_config_file='pulp/chips/siracusa/padframe.json'):
+    def __init__(self, parent, name, parser, soc_config_file='pulp/chips/siracusa/soc.json', cluster_config_file='pulp/chips/siracusa/cluster.json', padframe_config_file='pulp/chips/siracusa/padframe.json', accelerator: str=None):
         super(Pulp_open, self).__init__(parent, name)
 
         #
@@ -34,6 +34,9 @@ class Pulp_open(st.Component):
         soc_config_file = self.add_property('soc_config_file', soc_config_file)
         cluster_config_file = self.add_property('cluster_config_file', cluster_config_file)
         nb_cluster = self.add_property('nb_cluster', 1)
+        # Accelerator variant for the cluster(s): 'neureka' (default) or 'redmule'.
+        # None means "inherit from cluster.json's `accelerator` key, or default to neureka".
+        self.accelerator = accelerator
 
     
         #
@@ -56,7 +59,7 @@ class Pulp_open(st.Component):
         clusters = []
         for cid in range(0, nb_cluster):
             cluster_name = get_cluster_name(cid)
-            clusters.append(Cluster(self, cluster_name, config_file=cluster_config_file, cid=cid))
+            clusters.append(Cluster(self, cluster_name, config_file=cluster_config_file, cid=cid, accelerator=self.accelerator))
 
         # Soc
         soc = Soc(self, 'soc', parser, config_file=soc_config_file, chip=self, cluster=clusters[0])


### PR DESCRIPTION
### Summary

Integrates the existing Light_RedMulE model (`pulp/light_redmule/`) into the Siracusa cluster as a memory-mapped accelerator, **mutually exclusive with Neureka** (they share the L1 `neureka_in` TCDM ingress port). Selection is controlled from Python via an `accelerator` kwarg, defaulting to `neureka` so current behaviour is unchanged.

### Changes

- `pulp/chips/siracusa/cluster.py`:
  - New `accelerator` kwarg on `Cluster.__init__` (values: `'neureka'` | `'redmule'`). Falls back to the `accelerator` key in `cluster.json`, then to `'neureka'`.
  - Exactly one of Neureka / Light_RedMulE is instantiated; all its bindings (wmem out, periph_ico mapping, IRQ, TCDM `neureka_in`) are gated behind the selection.
- `pulp/chips/siracusa/pulp_open.py`: propagate the same `accelerator` kwarg to the `Cluster` call, so callers (e.g. `Pulp_open_board`) can select via Python without editing `cluster.json`.
- `pulp/chips/siracusa/cluster.json`:
  - Default `"accelerator": "neureka"` to preserve existing behaviour.
  - New `redmule` peripheral entry at `0x10201C00` (size `0x200`) with a Light_RedMulE configuration (`elem_size=4`, `ce_height=12`, `ce_width=4`, queue depth 8), used only when the accelerator is switched to `redmule`.

### Usage

```python
# Default (unchanged): Neureka
Pulp_open(parent, 'chip', parser)
# Opt-in Light_RedMulE variant
Pulp_open(parent, 'chip', parser, accelerator='redmule')
```

### Why

Unblocks [Deeploy](https://github.com/pulp-platform/Deeploy) support for a new `Siracusa_w_redmule` target: the compiler needs the accelerator visible in the Siracusa chip model so generated C code can issue the Light_RedMulE register sequence. The Deeploy side of the integration (MAGIA-style register protocol matching PR #70's `I_INPUT_V2`) is a separate downstream change.

### Scope & compatibility

- Non-invasive: no changes to `pulp/light_redmule/`, Neureka, or cluster infrastructure.
- Default `accelerator='neureka'` keeps every existing `siracusa` consumer bit-identical.
- Switching to `redmule` disables Neureka (including its `wmem_out`, IRQ and `neureka_in` bindings) in the same cluster.

### Testing

Builds cleanly under `make TARGETS="siracusa"` on current `master` in both modes. End-to-end validation (Deeploy `testFloatMatmul` through GVSoC on the `redmule` variant) is pending the companion Deeploy-side PR; this change stands alone as a Siracusa configuration update.
