### PR TITLE
MAGIA-V2: L1-to-L1 cross-tile access with narrow-wide floonoc

### DIFF
--- a/pulp/chips/magia_v2/soc.py
+++ b/pulp/chips/magia_v2/soc.py
@@ -181,9 +181,9 @@ class MagiaV2Soc(gvsoc.systree.Component):
                 print(f"[NoC] Adding cluster {id} at position x={x} y={y}")
                 cluster[id].o_KILLER_OUTPUT(killer.i_INPUT())
                 cluster[id].o_NARROW_OUTPUT(noc.i_NARROW_INPUT(x,y))
-                noc.o_NARROW_MAP(cluster[id].i_NARROW_INPUT(),name=f'tile-{id}-l1-mem',base=MagiaArch.L1_ADDR_START+(id*MagiaArch.L1_TILE_OFFSET),size=MagiaArch.L1_SIZE,x=x,y=y,rm_base=False)
+                noc.o_NARROW_MAP(cluster[id].i_NARROW_INPUT(),name=f'narrow-tile-{id}-l1-mem',base=MagiaArch.L1_ADDR_START+(id*MagiaArch.L1_TILE_OFFSET),size=MagiaArch.L1_SIZE,x=x,y=y,rm_base=False)
                 cluster[id].o_WIDE_OUTPUT(noc.i_WIDE_INPUT(x,y))
-                noc.o_WIDE_MAP(cluster[id].i_WIDE_INPUT(),name=f'tile-{id}-l1-mem',base=MagiaArch.L1_ADDR_START+(id*MagiaArch.L1_TILE_OFFSET),size=MagiaArch.L1_SIZE,x=x,y=y,rm_base=False,remove_offset=(id*MagiaArch.L1_TILE_OFFSET))
+                noc.o_WIDE_MAP(cluster[id].i_WIDE_INPUT(),name=f'wide-tile-{id}-l1-mem',base=MagiaArch.L1_ADDR_START+(id*MagiaArch.L1_TILE_OFFSET),size=MagiaArch.L1_SIZE,x=x,y=y,rm_base=False)
                 id += 1
 
         # Bind memory to noc

--- a/pulp/chips/magia_v2/soc.py
+++ b/pulp/chips/magia_v2/soc.py
@@ -181,6 +181,7 @@ class MagiaV2Soc(gvsoc.systree.Component):
                 print(f"[NoC] Adding cluster {id} at position x={x} y={y}")
                 cluster[id].o_KILLER_OUTPUT(killer.i_INPUT())
                 cluster[id].o_NARROW_OUTPUT(noc.i_NARROW_INPUT(x,y))
+                noc.o_NARROW_MAP(cluster[id].i_NARROW_INPUT(),name=f'tile-{id}-l1-mem',base=MagiaArch.L1_ADDR_START+(id*MagiaArch.L1_TILE_OFFSET),size=MagiaArch.L1_SIZE,x=x,y=y,rm_base=False)
                 cluster[id].o_WIDE_OUTPUT(noc.i_WIDE_INPUT(x,y))
                 noc.o_WIDE_MAP(cluster[id].i_WIDE_INPUT(),name=f'tile-{id}-l1-mem',base=MagiaArch.L1_ADDR_START+(id*MagiaArch.L1_TILE_OFFSET),size=MagiaArch.L1_SIZE,x=x,y=y,rm_base=False,remove_offset=(id*MagiaArch.L1_TILE_OFFSET))
                 id += 1

--- a/pulp/chips/magia_v2/tile.py
+++ b/pulp/chips/magia_v2/tile.py
@@ -288,6 +288,27 @@ class MagiaV2Tile(gvsoc.systree.Component):
                         base=MagiaArch.SPATZ_CTRL_START,
                         size=MagiaArch.SPATZ_CTRL_SIZE, rm_base=True)
             
+        # Bind obi xbar so that it can communicate with local L1
+        obi_xbar.o_MAP(l1_tcdm.i_INPUT(0), name="local-l1-mem",
+                    base=MagiaArch.L1_ADDR_START+(tid*MagiaArch.L1_TILE_OFFSET),
+                    size=MagiaArch.L1_SIZE, rm_base=False, remove_offset=(tid*MagiaArch.L1_TILE_OFFSET))
+        # Bind obi xbar so that it can communicate with tile xbar to get access to remote tiles l1 and reserved mem
+        for tile_id in range(0,tree.nb_clusters):
+            if (tile_id!=tid): #skip yourself
+                obi_xbar.o_MAP(tile_xbar.i_INPUT(), name=f'obi2axi-off-tile-{tile_id}-l1-mem',
+                        base=MagiaArch.L1_ADDR_START+(tile_id*MagiaArch.L1_TILE_OFFSET),
+                        size=MagiaArch.L1_SIZE, rm_base=False)
+        # Bind tile xbar so that it can coomunicate with obi xbar l1 mem
+        tile_xbar.o_MAP(obi_xbar.i_INPUT(), name="axi-to-obi-l1-mem",
+                        base=MagiaArch.L1_ADDR_START+(tid*MagiaArch.L1_TILE_OFFSET),
+                        size=MagiaArch.L1_SIZE, rm_base=False)
+        # Bind tile xbar so that it can communicate with remote tiles l1 and reserved mem
+        for tile_id in range(0,tree.nb_clusters):
+            if (tile_id!=tid): #skip yourself
+                tile_xbar.o_MAP(self.__i_NARROW_OUTPUT(), name=f'axi-to-off-tile-{tile_id}-l1-mem',
+                        base=MagiaArch.L1_ADDR_START+(tile_id*MagiaArch.L1_TILE_OFFSET),
+                        size=MagiaArch.L1_SIZE, rm_base=False)
+            
         # Bind NoC wide channel so that it can communicate with local L1
         self.__o_WIDE_INPUT(l1_tcdm.i_DMA_INPUT())
         

--- a/pulp/chips/magia_v2/tile.py
+++ b/pulp/chips/magia_v2/tile.py
@@ -71,7 +71,7 @@ class MagiaTileTcdm(gvsoc.systree.Component):
         banks = []
         for i in range(nb_banks):
             # Instantiate a new memory bank
-            bank = memory.Memory(self, f'bank_{i}', atomics=True, size=bank_size, latency=MagiaDSE.TILE_TCDM_LATENCY)
+            bank = memory.Memory(self, f'bank_{i}', atomics=True, size=bank_size, latency=MagiaDSE.TILE_TCDM_LATENCY, truncate_size=bank_size)
             banks.append(bank)
 
             # Bind the new bank (slave) to the interleaver (master)
@@ -203,8 +203,7 @@ class MagiaV2Tile(gvsoc.systree.Component):
                                     ce_height           = 8,
                                     ce_width            = 8,
                                     ce_pipe             = 1,
-                                    queue_depth         = 1,
-                                    loc_base            = (tid*MagiaArch.L1_TILE_OFFSET))
+                                    queue_depth         = 1)
             
         # Fsync mm controller
         fsync_mm_ctrl = FSync_mm_ctrl(self,f'tile-{tid}-fs-ctrl-mm')
@@ -289,23 +288,24 @@ class MagiaV2Tile(gvsoc.systree.Component):
                         size=MagiaArch.SPATZ_CTRL_SIZE, rm_base=True)
             
         # Bind obi xbar so that it can communicate with local L1
-        obi_xbar.o_MAP(l1_tcdm.i_INPUT(0), name="local-l1-mem",
+        obi_xbar.o_MAP(l1_tcdm.i_INPUT(0), name="obi-to-l1-mem-local",
                     base=MagiaArch.L1_ADDR_START+(tid*MagiaArch.L1_TILE_OFFSET),
                     size=MagiaArch.L1_SIZE, rm_base=False, remove_offset=(tid*MagiaArch.L1_TILE_OFFSET))
-        # Bind obi xbar so that it can communicate with tile xbar to get access to remote tiles l1 and reserved mem
-        for tile_id in range(0,tree.nb_clusters):
-            if (tile_id!=tid): #skip yourself
-                obi_xbar.o_MAP(tile_xbar.i_INPUT(), name=f'obi2axi-off-tile-{tile_id}-l1-mem',
-                        base=MagiaArch.L1_ADDR_START+(tile_id*MagiaArch.L1_TILE_OFFSET),
-                        size=MagiaArch.L1_SIZE, rm_base=False)
         # Bind tile xbar so that it can coomunicate with obi xbar l1 mem
         tile_xbar.o_MAP(obi_xbar.i_INPUT(), name="axi-to-obi-l1-mem",
                         base=MagiaArch.L1_ADDR_START+(tid*MagiaArch.L1_TILE_OFFSET),
                         size=MagiaArch.L1_SIZE, rm_base=False)
+
+        # Bind obi xbar so that it can communicate with tile xbar to get access to remote tiles l1 and reserved mem
+        for tile_id in range(0,tree.nb_clusters):
+            if (tile_id!=tid): #skip yourself
+                obi_xbar.o_MAP(tile_xbar.i_INPUT(), name=f'obi-to-axi-{tile_id}-l1-mem-off-tile',
+                        base=MagiaArch.L1_ADDR_START+(tile_id*MagiaArch.L1_TILE_OFFSET),
+                        size=MagiaArch.L1_SIZE, rm_base=False)
         # Bind tile xbar so that it can communicate with remote tiles l1 and reserved mem
         for tile_id in range(0,tree.nb_clusters):
             if (tile_id!=tid): #skip yourself
-                tile_xbar.o_MAP(self.__i_NARROW_OUTPUT(), name=f'axi-to-off-tile-{tile_id}-l1-mem',
+                tile_xbar.o_MAP(self.__i_NARROW_OUTPUT(), name=f'axi-to-{tile_id}-l1-mem-off-tile',
                         base=MagiaArch.L1_ADDR_START+(tile_id*MagiaArch.L1_TILE_OFFSET),
                         size=MagiaArch.L1_SIZE, rm_base=False)
             


### PR DESCRIPTION
- Fixed L1 to L1 tile communication with Narrow-Wide Floonoc in MAGIA-V2 soc/tile
- Fix FlooNoC mapping lookup for overlapping narrow/wide regions

FlooNoC was resolving mappings only by address range, without distinguishing whether the request belonged to the narrow or wide network. When narrow and wide mappings overlapped on the same base/size region, a wide request could incorrectly match the corresponding narrow entry first, causing the wide-specific remove_offset to be ignored.

This change makes the lookup network-aware:

- o_NARROW_MAP() entries are marked as narrow-only
- o_WIDE_MAP() entries are marked as wide-only
- generic o_MAP() / o_MAP_DIR() entries remain valid for both networks

On the C++ side, get_entry() now filters mappings by both address range and network type, while preserving backward compatibility for generic mappings. This fixes wide accesses to tile L1 regions that require a non-zero remove_offset, without relying on mapping name ordering or insertion order.