### PR TITLE
Intergrate Spatz into Mempool

### DIFF
--- a/mempool-spatz.py
+++ b/mempool-spatz.py
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2020 ETH Zurich and University of Bologna
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pulp.mempool.mempool_system import MempoolSpatzSystem
+import gvsoc.runner as gvsoc
+
+GAPY_TARGET = True
+
+class Target(gvsoc.Target):
+
+    def __init__(self, parser, options):
+        super(Target, self).__init__(parser, options,
+            model=MempoolSpatzSystem, description="MempoolSpatzSystem")

--- a/minpool-spatz.py
+++ b/minpool-spatz.py
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2020 ETH Zurich and University of Bologna
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pulp.mempool.mempool_system import MinpoolSpatzSystem
+import gvsoc.runner as gvsoc
+
+GAPY_TARGET = True
+
+class Target(gvsoc.Target):
+
+    def __init__(self, parser, options):
+        super(Target, self).__init__(parser, options,
+            model=MinpoolSpatzSystem, description="MinpoolSpatzSystem")

--- a/pulp/mempool/hierarchical_cache.py
+++ b/pulp/mempool/hierarchical_cache.py
@@ -22,7 +22,7 @@ import math
 
 class Hierarchical_cache(gvsoc.systree.Component):
 
-    def __init__(self, parent: gvsoc.systree.Component, name: str, nb_cores: int=0, synchronous: bool=True):
+    def __init__(self, parent: gvsoc.systree.Component, name: str, nb_cores: int=0, synchronous: bool=True, , nb_fus_per_core: int=1):
 
         super(Hierarchical_cache, self).__init__(parent, name)
 
@@ -30,10 +30,10 @@ class Hierarchical_cache(gvsoc.systree.Component):
         # Properties
         #
 
-        line_width = nb_cores * 8
-        cache_size = nb_cores * 512
+        line_width = nb_fus_per_core * nb_cores * 8
+        cache_size = nb_fus_per_core * nb_cores * 512
         nb_l0_sets = 1
-        nb_l1_sets = nb_cores / 2
+        nb_l1_sets = nb_fus_per_core * nb_cores / 2
         nb_l0_lines = 4
         nb_l1_lines = cache_size / (line_width * nb_l1_sets)
         

--- a/pulp/mempool/mempool_cluster.py
+++ b/pulp/mempool/mempool_cluster.py
@@ -24,7 +24,7 @@ from pulp.mempool.mempool_group import Group
 
 class Cluster(st.Component):
 
-    def __init__(self, parent, name, parser, async_l1_interco: bool=False, terapool: bool=False, nb_cores_per_tile: int=4, nb_sub_groups_per_group: int=1, nb_groups: int=4, total_cores: int= 256, bank_factor: int=4, axi_data_width: int=64, nb_axi_masters_per_group: int=1, nb_dmas_per_group: int=1, terapool_group_latency: int=7):
+    def __init__(self, parent, name, parser, async_l1_interco: bool=False, terapool: bool=False, nb_cores_per_tile: int=4, nb_sub_groups_per_group: int=1, nb_groups: int=4, total_cores: int= 256, bank_factor: int=4, axi_data_width: int=64, nb_axi_masters_per_group: int=1, nb_dmas_per_group: int=1, terapool_group_latency: int=7, nb_fus_per_core: int=1):
         super().__init__(parent, name)
 
         ################################################################
@@ -32,7 +32,7 @@ class Cluster(st.Component):
         ################################################################
         # Hardware parameters 
         nb_tiles_per_group = int((total_cores/nb_groups)/nb_cores_per_tile)
-        nb_banks_per_group = int(total_cores/nb_groups) * bank_factor
+        nb_banks_per_group = int(total_cores/nb_groups) * bank_factor * nb_fus_per_core
 
         ################################################################
         ##########              Design Components             ##########
@@ -42,7 +42,7 @@ class Cluster(st.Component):
         for i in range(0, nb_groups):
             self.group_list.append(Group(self, f'group_{i}', parser=parser, async_l1_interco=async_l1_interco, terapool=terapool, group_id=i, nb_cores_per_tile=nb_cores_per_tile, 
                 nb_sub_groups_per_group=nb_sub_groups_per_group, nb_groups=nb_groups, total_cores=total_cores, bank_factor=bank_factor, axi_data_width=axi_data_width,
-                nb_dmas_per_group=nb_dmas_per_group, terapool_group_latency=terapool_group_latency))
+                nb_dmas_per_group=nb_dmas_per_group, terapool_group_latency=terapool_group_latency, nb_fus_per_core=nb_fus_per_core))
 
         # AXI Interface
         if terapool:

--- a/pulp/mempool/mempool_group.py
+++ b/pulp/mempool/mempool_group.py
@@ -27,7 +27,7 @@ from pulp.mempool.l2_interconnect.hierarchical_interco import Hierarchical_Inter
 
 class Group(st.Component):
 
-    def __init__(self, parent, name, parser, terapool: bool=False, async_l1_interco: bool=False, group_id: int=0, nb_cores_per_tile: int=4, nb_sub_groups_per_group: int=1, nb_groups: int=4, total_cores: int= 256, bank_factor: int=4, axi_data_width: int=64, nb_dmas_per_group: int=1, terapool_group_latency: int=7):
+    def __init__(self, parent, name, parser, terapool: bool=False, async_l1_interco: bool=False, group_id: int=0, nb_cores_per_tile: int=4, nb_sub_groups_per_group: int=1, nb_groups: int=4, total_cores: int= 256, bank_factor: int=4, axi_data_width: int=64, nb_dmas_per_group: int=1, terapool_group_latency: int=7, nb_fus_per_core: int=1):
         super().__init__(parent, name)
 
         ################################################################
@@ -38,12 +38,12 @@ class Group(st.Component):
             assert nb_dmas_per_group == nb_sub_groups_per_group
             nb_remote_group_ports = nb_groups - 1
             nb_tiles_per_sub_group = int((total_cores/nb_groups/nb_sub_groups_per_group)/nb_cores_per_tile)
-            nb_banks_per_sub_group = int((total_cores/nb_groups/nb_sub_groups_per_group)) * bank_factor
+            nb_banks_per_sub_group = int((total_cores/nb_groups/nb_sub_groups_per_group)) * bank_factor *nb_fus_per_core
         else:
             assert nb_dmas_per_group == 1
             nb_remote_ports = nb_groups - 1
             nb_tiles_per_group = int((total_cores/nb_groups)/nb_cores_per_tile)
-            nb_banks_per_tile = nb_cores_per_tile * bank_factor
+            nb_banks_per_tile = nb_cores_per_tile * bank_factor *nb_fus_per_core
 
         ################################################################
         ##########              Design Components             ##########
@@ -54,13 +54,14 @@ class Group(st.Component):
             self.sub_group_list = []
             for i in range(0, nb_sub_groups_per_group):
                 self.sub_group_list.append(Sub_group(self, f'sub_group_{i}', parser=parser, terapool=terapool, async_l1_interco=async_l1_interco, sub_group_id=i, group_id=group_id, nb_cores_per_tile=nb_cores_per_tile,
-                    nb_sub_groups_per_group=nb_sub_groups_per_group, nb_groups=nb_groups, total_cores=total_cores, bank_factor=bank_factor, axi_data_width=axi_data_width, terapool_group_latency=terapool_group_latency))
+                    nb_sub_groups_per_group=nb_sub_groups_per_group, nb_groups=nb_groups, total_cores=total_cores, bank_factor=bank_factor, axi_data_width=axi_data_width, terapool_group_latency=terapool_group_latency,
+                    nb_fus_per_core=nb_fus_per_core))
         else:
             # TIles
             self.tile_list = []
             for i in range(0, nb_tiles_per_group):
                 self.tile_list.append(Tile(self, f'tile_{i}', parser=parser, terapool=terapool, async_l1_interco=async_l1_interco, tile_id=i, sub_group_id=0, group_id=group_id, nb_cores_per_tile=nb_cores_per_tile,
-                    nb_sub_groups_per_group=1, nb_groups=nb_groups, total_cores=total_cores, bank_factor=bank_factor, axi_data_width=axi_data_width))
+                    nb_sub_groups_per_group=1, nb_groups=nb_groups, total_cores=total_cores, bank_factor=bank_factor, axi_data_width=axi_data_width, nb_fus_per_core=nb_fus_per_core))
 
         # TCDM Interconnect
         if terapool:
@@ -68,7 +69,7 @@ class Group(st.Component):
             group_remote_master_interleavers = []
             for i in range(0, nb_remote_group_ports):
                 group_remote_master_interleavers.append(Interleaver(self, f'group_remote_slave_interleaver_{i}', nb_slaves=nb_sub_groups_per_group*nb_tiles_per_sub_group,
-                    nb_masters=nb_sub_groups_per_group*nb_tiles_per_sub_group, interleaving_bits=int(math.log2(4*nb_cores_per_tile*bank_factor)), offset_translation=False))
+                    nb_masters=nb_sub_groups_per_group*nb_tiles_per_sub_group, interleaving_bits=int(math.log2(4*nb_cores_per_tile*bank_factor*nb_fus_per_core)), offset_translation=False))
 
             group_remote_out_interfaces = []
             for port in range(0, nb_remote_group_ports):
@@ -98,12 +99,12 @@ class Group(st.Component):
         else:
             #Group local interconnect
             group_local_interleaver = Interleaver(self, 'group_local_interleaver', nb_slaves=nb_tiles_per_group, nb_masters=nb_tiles_per_group,
-                interleaving_bits=int(math.log2(4*nb_cores_per_tile*bank_factor)), offset_translation=False)
+                interleaving_bits=int(math.log2(4*nb_cores_per_tile*bank_factor*nb_fus_per_core)), offset_translation=False)
 
             #Group Remote Slave Interconnect
             group_remote_master_interleavers = []
             for i in range(0, nb_remote_ports):
-                group_remote_master_interleavers.append(Interleaver(self, f'group_remote_slave_interleaver_{i}', nb_slaves=nb_tiles_per_group, nb_masters=nb_tiles_per_group, interleaving_bits=int(math.log2(4*nb_cores_per_tile*bank_factor)), offset_translation=False))
+                group_remote_master_interleavers.append(Interleaver(self, f'group_remote_slave_interleaver_{i}', nb_slaves=nb_tiles_per_group, nb_masters=nb_tiles_per_group, interleaving_bits=int(math.log2(4*nb_cores_per_tile*bank_factor*nb_fus_per_core)), offset_translation=False))
 
             group_remote_out_interfaces = []
             for port in range(0, nb_remote_ports):

--- a/pulp/mempool/mempool_sub_group.py
+++ b/pulp/mempool/mempool_sub_group.py
@@ -26,7 +26,7 @@ from pulp.mempool.l2_interconnect.hierarchical_interco import Hierarchical_Inter
 
 class Sub_group(st.Component):
 
-    def __init__(self, parent, name, parser, terapool: bool=False, async_l1_interco: bool=False, sub_group_id: int=0, group_id: int=0, nb_cores_per_tile: int=4, nb_sub_groups_per_group: int=4, nb_groups: int=4, total_cores: int=1024, bank_factor: int=4, axi_data_width: int=64, terapool_group_latency: int=7):
+    def __init__(self, parent, name, parser, terapool: bool=False, async_l1_interco: bool=False, sub_group_id: int=0, group_id: int=0, nb_cores_per_tile: int=4, nb_sub_groups_per_group: int=4, nb_groups: int=4, total_cores: int=1024, bank_factor: int=4, axi_data_width: int=64, terapool_group_latency: int=7, nb_fus_per_core: int=1):
         super().__init__(parent, name)
 
         ################################################################
@@ -36,7 +36,7 @@ class Sub_group(st.Component):
         nb_remote_group_ports = nb_groups - 1
         nb_remote_sub_group_ports = nb_sub_groups_per_group - 1
         nb_tiles_per_sub_group = int((total_cores/nb_groups/nb_sub_groups_per_group)/nb_cores_per_tile)
-        nb_banks_per_tile = nb_cores_per_tile * bank_factor
+        nb_banks_per_tile = nb_cores_per_tile * bank_factor * nb_fus_per_core
 
         ################################################################
         ##########              Design Components             ##########
@@ -45,16 +45,16 @@ class Sub_group(st.Component):
         self.tile_list = []
         for i in range(0, nb_tiles_per_sub_group):
             self.tile_list.append(Tile(self, f'tile_{i}',parser=parser, terapool=terapool, async_l1_interco=async_l1_interco, tile_id=i, sub_group_id=sub_group_id, group_id=group_id, nb_cores_per_tile=nb_cores_per_tile,
-                nb_sub_groups_per_group=nb_sub_groups_per_group, nb_groups=nb_groups, total_cores=total_cores, bank_factor=bank_factor, terapool_group_latency=terapool_group_latency))
+                nb_sub_groups_per_group=nb_sub_groups_per_group, nb_groups=nb_groups, total_cores=total_cores, bank_factor=bank_factor, terapool_group_latency=terapool_group_latency, nb_fus_per_core=nb_fus_per_core))
 
         #Sub Group local interconnect
         sub_group_local_interleaver = Interleaver(self, 'sub_group_local_interleaver', nb_slaves=nb_tiles_per_sub_group, nb_masters=nb_tiles_per_sub_group,
-            interleaving_bits=int(math.log2(4*nb_cores_per_tile*bank_factor)), offset_translation=False)
+            interleaving_bits=int(math.log2(4*nb_cores_per_tile*bank_factor*nb_fus_per_core)), offset_translation=False)
 
         #Sub Group Remote Slave Interconnect
         sub_group_remote_master_interleavers = []
         for i in range(0, nb_remote_sub_group_ports):
-            sub_group_remote_master_interleavers.append(Interleaver(self, f'sub_group_remote_slave_interleaver_{i}', nb_slaves=nb_tiles_per_sub_group, nb_masters=nb_tiles_per_sub_group, interleaving_bits=int(math.log2(4*nb_cores_per_tile*bank_factor)), offset_translation=False))
+            sub_group_remote_master_interleavers.append(Interleaver(self, f'sub_group_remote_slave_interleaver_{i}', nb_slaves=nb_tiles_per_sub_group, nb_masters=nb_tiles_per_sub_group, interleaving_bits=int(math.log2(4*nb_cores_per_tile*bank_factor*nb_fus_per_core)), offset_translation=False))
 
         sub_group_out_interfaces = []
         for port in range(0, nb_remote_group_ports):

--- a/pulp/mempool/mempool_system.py
+++ b/pulp/mempool/mempool_system.py
@@ -39,7 +39,7 @@ from pulp.mempool.l2_subsystem import L2_subsystem
 
 class System(st.Component):
 
-    def __init__(self, parent, name, parser, terapool: bool=False, nb_cores_per_tile: int=4, nb_sub_groups_per_group: int=1, nb_groups: int=4, total_cores: int= 256, bank_factor: int=4, axi_data_width: int=64, nb_axi_masters_per_group: int=1, nb_dmas_per_group: int=1, l2_size: int=0x1000000, nb_l2_banks: int=4, terapool_group_latency: int=7):
+    def __init__(self, parent, name, parser, terapool: bool=False, nb_cores_per_tile: int=4, nb_sub_groups_per_group: int=1, nb_groups: int=4, total_cores: int= 256, bank_factor: int=4, axi_data_width: int=64, nb_axi_masters_per_group: int=1, nb_dmas_per_group: int=1, l2_size: int=0x1000000, nb_l2_banks: int=4, terapool_group_latency: int=7, nb_fus_per_core: int=1):
         super().__init__(parent, name)
 
         ################################################################
@@ -71,7 +71,8 @@ class System(st.Component):
         #Mempool cluster
         mempool_cluster=Cluster(self, 'mempool_cluster', async_l1_interco=async_l1_interco, terapool=terapool, parser=parser, nb_cores_per_tile=nb_cores_per_tile,
                             nb_sub_groups_per_group=nb_sub_groups_per_group, nb_groups=nb_groups, total_cores=total_cores, bank_factor=bank_factor,
-                            axi_data_width=axi_data_width, nb_axi_masters_per_group=nb_axi_masters_per_group, nb_dmas_per_group=nb_dmas_per_group, terapool_group_latency=terapool_group_latency)
+                            axi_data_width=axi_data_width, nb_axi_masters_per_group=nb_axi_masters_per_group, nb_dmas_per_group=nb_dmas_per_group, terapool_group_latency=terapool_group_latency, 
+                            nb_fus_per_core=nb_fus_per_core)
 
         # Boot Rom
         rom = memory.Memory(self, 'rom', size=0x1000, width_log2=(axi_data_width - 1).bit_length(), stim_file=self.get_file_path('pulp/chips/spatz/rom.bin'))
@@ -207,7 +208,19 @@ class MempoolSystem(st.Component):
 
         clock = Clock_domain(self, 'clock', frequency=500000000)
 
-        soc = System(self, 'mempool_soc', parser, terapool=False, nb_cores_per_tile=4, nb_sub_groups_per_group=1, nb_groups=4, total_cores=256, bank_factor=4, axi_data_width=64, nb_axi_masters_per_group=1, nb_dmas_per_group=1, l2_size=0x400000, nb_l2_banks=4)
+        soc = System(self, 'mempool_soc', parser, terapool=False, nb_cores_per_tile=4, nb_sub_groups_per_group=1, nb_groups=4, total_cores=256, bank_factor=4, axi_data_width=64, nb_axi_masters_per_group=1, nb_dmas_per_group=1, l2_size=0x400000, nb_l2_banks=4, nb_fus_per_core=1)
+
+        self.bind(clock, 'out', soc, 'clock')
+
+class MempoolSpatzSystem(st.Component):
+
+    def __init__(self, parent, name, parser, options):
+
+        super(MempoolSpatzSystem, self).__init__(parent, name, options=options)
+
+        clock = Clock_domain(self, 'clock', frequency=500000000)
+
+        soc = System(self, 'mempool_soc', parser, terapool=False, nb_cores_per_tile=1, nb_sub_groups_per_group=1, nb_groups=4, total_cores=64, bank_factor=4, axi_data_width=64, nb_axi_masters_per_group=1, nb_dmas_per_group=1, l2_size=0x400000, nb_l2_banks=4, nb_fus_per_core=4)
 
         self.bind(clock, 'out', soc, 'clock')
 
@@ -219,7 +232,19 @@ class MinpoolSystem(st.Component):
 
         clock = Clock_domain(self, 'clock', frequency=500000000)
 
-        soc = System(self, 'mempool_soc', parser, terapool=False, nb_cores_per_tile=4, nb_sub_groups_per_group=1, nb_groups=4, total_cores=16, bank_factor=4, axi_data_width=32, nb_axi_masters_per_group=1, nb_dmas_per_group=1, l2_size=0x400000, nb_l2_banks=4)
+        soc = System(self, 'mempool_soc', parser, terapool=False, nb_cores_per_tile=4, nb_sub_groups_per_group=1, nb_groups=4, total_cores=16, bank_factor=4, axi_data_width=32, nb_axi_masters_per_group=1, nb_dmas_per_group=1, l2_size=0x400000, nb_l2_banks=4, nb_fus_per_core=1)
+
+        self.bind(clock, 'out', soc, 'clock')
+
+class MinpoolSpatzSystem(st.Component):
+
+    def __init__(self, parent, name, parser, options):
+
+        super(MinpoolSpatzSystem, self).__init__(parent, name, options=options)
+
+        clock = Clock_domain(self, 'clock', frequency=500000000)
+
+        soc = System(self, 'mempool_soc', parser, terapool=False, nb_cores_per_tile=1, nb_sub_groups_per_group=1, nb_groups=4, total_cores=4, bank_factor=4, axi_data_width=32, nb_axi_masters_per_group=1, nb_dmas_per_group=1, l2_size=0x400000, nb_l2_banks=4, nb_fus_per_core=4)
 
         self.bind(clock, 'out', soc, 'clock')
 
@@ -231,6 +256,18 @@ class TerapoolSystem(st.Component):
 
         clock = Clock_domain(self, 'clock', frequency=500000000)
 
-        soc = System(self, 'mempool_soc', parser, terapool=True, nb_cores_per_tile=8, nb_sub_groups_per_group=4, nb_groups=4, total_cores=1024, bank_factor=4, axi_data_width=64, nb_axi_masters_per_group=4, nb_dmas_per_group=4, l2_size=0x1000000, nb_l2_banks=16, terapool_group_latency=9)
+        soc = System(self, 'mempool_soc', parser, terapool=True, nb_cores_per_tile=8, nb_sub_groups_per_group=4, nb_groups=4, total_cores=1024, bank_factor=4, axi_data_width=64, nb_axi_masters_per_group=4, nb_dmas_per_group=4, l2_size=0x1000000, nb_l2_banks=16, terapool_group_latency=9, nb_fus_per_core=1)
+
+        self.bind(clock, 'out', soc, 'clock')
+
+class TerapoolSpatzSystem(st.Component):
+    
+    def __init__(self, parent, name, parser, options):
+
+        super(TerapoolSpatzSystem, self).__init__(parent, name, options=options)
+
+        clock = Clock_domain(self, 'clock', frequency=500000000)
+
+        soc = System(self, 'mempool_soc', parser, terapool=True, nb_cores_per_tile=1, nb_sub_groups_per_group=4, nb_groups=4, total_cores=128, bank_factor=4, axi_data_width=64, nb_axi_masters_per_group=4, nb_dmas_per_group=4, l2_size=0x1000000, nb_l2_banks=16, terapool_group_latency=9, nb_fus_per_core=8)
 
         self.bind(clock, 'out', soc, 'clock')

--- a/pulp/mempool/mempool_tile.py
+++ b/pulp/mempool/mempool_tile.py
@@ -25,15 +25,15 @@ import gvsoc.systree as st
 from pulp.snitch.sequencer import Sequencer
 from pulp.mempool.l1_interconnect.l1_address_scrambler import L1AddressScrambler
 
+from pulp.cpu.iss.spatz_config import SpatzConfig
+from pulp.cpu.iss.spatz_mempool import SpatzMempool
+
 class Tile(st.Component):
 
-    def __init__(self, parent, name, parser, terapool: bool=False, async_l1_interco: bool=False, tile_id: int=0, sub_group_id: int=0, group_id: int=0, nb_cores_per_tile: int=4, nb_sub_groups_per_group: int=1, nb_groups: int=4, total_cores: int= 256, bank_factor: int=4, axi_data_width: int=64, terapool_group_latency: int=7):
+    def __init__(self, parent, name, parser, terapool: bool=False, async_l1_interco: bool=False, tile_id: int=0, sub_group_id: int=0, group_id: int=0, nb_cores_per_tile: int=4, nb_sub_groups_per_group: int=1, nb_groups: int=4, total_cores: int= 256, bank_factor: int=4, axi_data_width: int=64, terapool_group_latency: int=7, nb_fus_per_core: int=1):
         super().__init__(parent, name)
 
         [args, __] = parser.parse_known_args()
-
-        # Set it to true to swtich to snitch new fast model
-        fast_model = True
 
         ################################################################
         ##########               Design Variables             ##########
@@ -45,29 +45,28 @@ class Tile(st.Component):
         # global_tile_id = tile_id + group_id * nb_tiles_per_group
         Xfrep = 0
         # stack_size_per_tile = 0x800
-        mem_size = nb_cores_per_tile * bank_factor * 1024
+        mem_size = nb_cores_per_tile * bank_factor * nb_fus_per_core * 1024
 
         # Snitch core complex
         self.int_cores = []
-        self.fp_cores = []
         bus_watchpoints = []
-        if Xfrep:
-            fpu_sequencers = []
 
         ################################################################
         ##########              Design Components             ##########
         ################################################################
 
         # Snitch TCDM (L1 subsystem)
+        # nb_pe is the number of local master ports within the tile
+        nb_pe = nb_cores_per_tile * (nb_fus_per_core + 1)
         l1 = l1_subsystem.L1_subsystem(self, 'l1', terapool=terapool, \
                                         async_l1_interco=async_l1_interco, tile_id=tile_id, sub_group_id=sub_group_id, group_id=group_id, \
                                         nb_tiles_per_sub_group=nb_tiles_per_sub_group, nb_sub_groups_per_group=nb_sub_groups_per_group, \
                                         nb_groups=nb_groups, nb_remote_local_masters=1, nb_remote_group_masters=nb_remote_group_ports, \
-                                        nb_remote_sub_group_masters=nb_remote_sub_group_ports, nb_pe=nb_cores_per_tile, size=mem_size, \
-                                        bandwidth=4, nb_banks_per_tile=nb_cores_per_tile*bank_factor, axi_data_width=axi_data_width, \
+                                        nb_remote_sub_group_masters=nb_remote_sub_group_ports, nb_pe=nb_pe, size=mem_size, \
+                                        bandwidth=4, nb_banks_per_tile=nb_cores_per_tile*nb_fus_per_core*bank_factor, axi_data_width=axi_data_width, \
                                         terapool_group_latency=terapool_group_latency)
         # Shared icache
-        icache = Hierarchical_cache(self, 'shared_icache', nb_cores=nb_cores_per_tile)
+        icache = Hierarchical_cache(self, 'shared_icache', nb_cores=nb_cores_per_tile, nb_fus_per_core=nb_fus_per_core)
 
         # Address Scrambler
         l1_addr_scrambler_list = []
@@ -75,31 +74,21 @@ class Tile(st.Component):
             l1_addr_scrambler_list.append(L1AddressScrambler(self, f'addr_scrambler{i}',
                                                        bypass=False, num_tiles=int(total_cores/nb_cores_per_tile),
                                                        seq_mem_size_per_tile=512*nb_cores_per_tile, byte_offset=2,
-                                                       num_banks_per_tile=nb_cores_per_tile*bank_factor))
+                                                       num_banks_per_tile=nb_cores_per_tile*nb_fus_per_core*bank_factor))
 
         # Route
         ico_list=[]
-        for i in range(0, nb_cores_per_tile):
+        for i in range(0, nb_pe):
             ico_list.append(router.Router(self, 'ico%d' % i, bandwidth=4, latency=0))
         axi_ico = router.Router(self, 'axi_ico', bandwidth=axi_data_width, latency=1)
         axi_ico.add_mapping('output')
 
         # Core Complex
         for core_id in range(0, nb_cores_per_tile):
-            if fast_model:
-                self.int_cores.append(iss.SnitchFast(self, f'pe{core_id}', isa="rv32imaf",
-                    core_id=group_id*nb_sub_groups_per_group*nb_tiles_per_sub_group*nb_cores_per_tile+sub_group_id*nb_tiles_per_sub_group*nb_cores_per_tile+tile_id*nb_cores_per_tile+core_id,
-                    htif=False, pulp_v2=True, wakeup_counter=True, nb_outstanding=8, single_regfile=True, ssr=False, sequencer=False
-                ))
-            else:
-                self.int_cores.append(iss.Snitch(self, f'pe{core_id}', isa="rv32imaf", htif=False, \
-                    core_id=group_id*nb_sub_groups_per_group*nb_tiles_per_sub_group*nb_cores_per_tile+sub_group_id*nb_tiles_per_sub_group*nb_cores_per_tile+tile_id*nb_cores_per_tile+core_id,
-                    pulp_v2=True))
-                self.fp_cores.append(iss.Snitch_fp_ss(self, f'fp_ss{core_id}', isa="rv32imaf", htif=False, \
-                    core_id=group_id*nb_sub_groups_per_group*nb_tiles_per_sub_group*nb_cores_per_tile+sub_group_id*nb_tiles_per_sub_group*nb_cores_per_tile+tile_id*nb_cores_per_tile+core_id,
-                    pulp_v2=True))
-                if Xfrep:
-                    fpu_sequencers.append(Sequencer(self, f'fpu_sequencer{core_id}', latency=0))
+            config = SpatzConfig(isa="rv32imafv", fetch_enable=False,
+                boot_addr=0, hart_id=group_id*nb_sub_groups_per_group*nb_tiles_per_sub_group*nb_cores_per_tile+sub_group_id*nb_tiles_per_sub_group*nb_cores_per_tile+tile_id*nb_cores_per_tile+core_id,
+                htif=False, nb_lanes=nb_fus_per_core, lane_width=4)
+            self.int_cores.append(SpatzMempool(self, f'pe{core_id}', config=config))
 
         ################################################################
         ##########               Design Bindings              ##########
@@ -112,8 +101,8 @@ class Tile(st.Component):
         ##########################################################################
 
         # ICO --> L1 TCDM
-        for i in range(0, nb_cores_per_tile):
-            ico_list[i].add_mapping('l1', base=0x00000000, remove_offset=0x00000000, size=total_cores * bank_factor * 1024)
+        for i in range(0, nb_pe):
+            ico_list[i].add_mapping('l1', base=0x00000000, remove_offset=0x00000000, size=total_cores * nb_fus_per_core *bank_factor * 1024)
             self.bind(ico_list[i], 'l1', l1, f'pe_in{i}')
 
         # L1 TCDM --> Remote TCDM interfaces
@@ -133,8 +122,9 @@ class Tile(st.Component):
         # ICO -> AXI -> L2 Memory
         for i in range(0, nb_cores_per_tile):
             # Add default mapping for the others
-            ico_list[i].add_mapping('axi', latency=4)
-            self.bind(ico_list[i], 'axi', axi_ico, 'input')
+            core_id = i * (1 + nb_fus_per_core)
+            ico_list[core_id].add_mapping('axi', latency=4)
+            self.bind(ico_list[core_id], 'axi', axi_ico, 'input')
 
         ###########################################################
         #                                       |--> ROM          #
@@ -154,39 +144,24 @@ class Tile(st.Component):
             self.bind(self, f'barrier_ack_{core_id}', self.int_cores[core_id], 'barrier_ack')
 
         # Core Interconnections
+        pe_id = 0
         for core_id in range(0, nb_cores_per_tile):
             # Icache
             self.bind(self.int_cores[core_id], 'flush_cache_req', icache, 'flush')
             self.bind(icache, 'flush_ack', self.int_cores[core_id], 'flush_cache_ack')
 
             # Snitch integer cores
-            self.bind(self.int_cores[core_id], 'data', l1_addr_scrambler_list[core_id], 'input')
+            self.bind(self.int_cores[core_id], 'data', l1_addr_scrambler_list[pe_id], 'input')
             self.bind(self.int_cores[core_id], 'fetch', icache, 'input_%d' % core_id)
             self.bind(self, 'loader_start', self.int_cores[core_id], 'fetchen')
             self.bind(self, 'loader_entry', self.int_cores[core_id], 'bootaddr')
-
-            if not fast_model:
-                # Snitch fp subsystems
-                # Pay attention to interactions and bandwidth between subsystem and tohost.
-                self.bind(self.fp_cores[core_id], 'data', l1_addr_scrambler_list[core_id], 'input')
-                # FP subsystem doesn't fetch instructions from core->ico->memory, but from integer cores acc_req.
-                self.bind(self, 'loader_start', self.fp_cores[core_id], 'fetchen')
-                self.bind(self, 'loader_entry', self.fp_cores[core_id], 'bootaddr')
-
+            
             # Scrambler
-            self.bind(l1_addr_scrambler_list[core_id], 'output', ico_list[core_id], 'input')
+            self.bind(l1_addr_scrambler_list[pe_id], 'output', ico_list[pe_id], 'input')
+            pe_id += 1
 
-            # Use WireMaster & WireSlave
-            # Add fpu sequence buffer in between int core and fp core to issue instructions
-            if not fast_model:
-                if Xfrep:
-                    self.bind(self.int_cores[core_id], 'acc_req', fpu_sequencers[core_id], 'input')
-                    self.bind(fpu_sequencers[core_id], 'output', self.fp_cores[core_id], 'acc_req')
-                    self.bind(self.int_cores[core_id], 'acc_req_ready', fpu_sequencers[core_id], 'acc_req_ready')
-                    self.bind(fpu_sequencers[core_id], 'acc_req_ready_o', self.fp_cores[core_id], 'acc_req_ready')
-                else:
-                    # Comment out if we want to add sequencer
-                    self.bind(self.int_cores[core_id], 'acc_req', self.fp_cores[core_id], 'acc_req')
-                    self.bind(self.int_cores[core_id], 'acc_req_ready', self.fp_cores[core_id], 'acc_req_ready')
-
-                self.bind(self.fp_cores[core_id], 'acc_rsp', self.int_cores[core_id], 'acc_rsp')
+            # Spatz
+            for port in range(0, nb_fus_per_core):
+                self.bind(self.int_cores[core_id], f'vlsu_{port}', l1_addr_scrambler_list[pe_id], 'input')
+                self.bind(l1_addr_scrambler_list[pe_id], 'output', ico_list[pe_id], 'input')
+                pe_id += 1

--- a/pulp/mempool/mempool_tile.py
+++ b/pulp/mempool/mempool_tile.py
@@ -35,6 +35,10 @@ class Tile(st.Component):
 
         [args, __] = parser.parse_known_args()
 
+        # Set it to true to swtich to snitch new fast model
+        fast_model = True
+        use_spatz = nb_fus_per_core > 1
+
         ################################################################
         ##########               Design Variables             ##########
         ################################################################
@@ -49,7 +53,10 @@ class Tile(st.Component):
 
         # Snitch core complex
         self.int_cores = []
+        self.fp_cores = []
         bus_watchpoints = []
+        if Xfrep and not use_spatz:
+            fpu_sequencers = []
 
         ################################################################
         ##########              Design Components             ##########
@@ -57,7 +64,7 @@ class Tile(st.Component):
 
         # Snitch TCDM (L1 subsystem)
         # nb_pe is the number of local master ports within the tile
-        nb_pe = nb_cores_per_tile * (nb_fus_per_core + 1)
+        nb_pe = nb_cores_per_tile * (nb_fus_per_core + 1) if use_spatz else nb_cores_per_tile
         l1 = l1_subsystem.L1_subsystem(self, 'l1', terapool=terapool, \
                                         async_l1_interco=async_l1_interco, tile_id=tile_id, sub_group_id=sub_group_id, group_id=group_id, \
                                         nb_tiles_per_sub_group=nb_tiles_per_sub_group, nb_sub_groups_per_group=nb_sub_groups_per_group, \
@@ -85,10 +92,26 @@ class Tile(st.Component):
 
         # Core Complex
         for core_id in range(0, nb_cores_per_tile):
-            config = SpatzConfig(isa="rv32imafv", fetch_enable=False,
-                boot_addr=0, hart_id=group_id*nb_sub_groups_per_group*nb_tiles_per_sub_group*nb_cores_per_tile+sub_group_id*nb_tiles_per_sub_group*nb_cores_per_tile+tile_id*nb_cores_per_tile+core_id,
-                htif=False, nb_lanes=nb_fus_per_core, lane_width=4)
-            self.int_cores.append(SpatzMempool(self, f'pe{core_id}', config=config))
+            core_global_id = group_id*nb_sub_groups_per_group*nb_tiles_per_sub_group*nb_cores_per_tile+sub_group_id*nb_tiles_per_sub_group*nb_cores_per_tile+tile_id*nb_cores_per_tile+core_id
+
+            if use_spatz:
+                config = SpatzConfig(isa="rv32imafv", fetch_enable=False,
+                    boot_addr=0, hart_id=core_global_id,
+                    htif=False, nb_lanes=nb_fus_per_core, lane_width=4)
+                self.int_cores.append(SpatzMempool(self, f'pe{core_id}', config=config))
+
+            elif fast_model:
+                self.int_cores.append(iss.SnitchFast(self, f'pe{core_id}', isa="rv32imaf",
+                    core_id=core_global_id, htif=False, pulp_v2=True, wakeup_counter=True, nb_outstanding=8
+                ))
+
+            else:
+                self.int_cores.append(iss.Snitch(self, f'pe{core_id}', isa="rv32imaf", htif=False, \
+                    core_id=core_global_id, pulp_v2=True))
+                self.fp_cores.append(iss.Snitch_fp_ss(self, f'fp_ss{core_id}', isa="rv32imaf", htif=False, \
+                    core_id=core_global_id, pulp_v2=True))
+                if Xfrep:
+                    fpu_sequencers.append(Sequencer(self, f'fpu_sequencer{core_id}', latency=0))
 
         ################################################################
         ##########               Design Bindings              ##########
@@ -102,7 +125,7 @@ class Tile(st.Component):
 
         # ICO --> L1 TCDM
         for i in range(0, nb_pe):
-            ico_list[i].add_mapping('l1', base=0x00000000, remove_offset=0x00000000, size=total_cores * nb_fus_per_core *bank_factor * 1024)
+            ico_list[i].add_mapping('l1', base=0x00000000, remove_offset=0x00000000, size=total_cores * nb_fus_per_core * bank_factor * 1024)
             self.bind(ico_list[i], 'l1', l1, f'pe_in{i}')
 
         # L1 TCDM --> Remote TCDM interfaces
@@ -122,7 +145,7 @@ class Tile(st.Component):
         # ICO -> AXI -> L2 Memory
         for i in range(0, nb_cores_per_tile):
             # Add default mapping for the others
-            core_id = i * (1 + nb_fus_per_core)
+            core_id = i * (1 + nb_fus_per_core) if use_spatz else i
             ico_list[core_id].add_mapping('axi', latency=4)
             self.bind(ico_list[core_id], 'axi', axi_ico, 'input')
 
@@ -155,13 +178,35 @@ class Tile(st.Component):
             self.bind(self.int_cores[core_id], 'fetch', icache, 'input_%d' % core_id)
             self.bind(self, 'loader_start', self.int_cores[core_id], 'fetchen')
             self.bind(self, 'loader_entry', self.int_cores[core_id], 'bootaddr')
+
+            if not use_spatz and not fast_model:
+                # Snitch fp subsystems
+                # Pay attention to interactions and bandwidth between subsystem and tohost.
+                self.bind(self.fp_cores[core_id], 'data', l1_addr_scrambler_list[pe_id], 'input')
+                # FP subsystem doesn't fetch instructions from core->ico->memory, but from integer cores acc_req.
+                self.bind(self, 'loader_start', self.fp_cores[core_id], 'fetchen')
+                self.bind(self, 'loader_entry', self.fp_cores[core_id], 'bootaddr')
             
             # Scrambler
             self.bind(l1_addr_scrambler_list[pe_id], 'output', ico_list[pe_id], 'input')
             pe_id += 1
 
-            # Spatz
-            for port in range(0, nb_fus_per_core):
-                self.bind(self.int_cores[core_id], f'vlsu_{port}', l1_addr_scrambler_list[pe_id], 'input')
-                self.bind(l1_addr_scrambler_list[pe_id], 'output', ico_list[pe_id], 'input')
-                pe_id += 1
+            if use_spatz:
+                for port in range(0, nb_fus_per_core):
+                    self.bind(self.int_cores[core_id], f'vlsu_{port}', l1_addr_scrambler_list[pe_id], 'input')
+                    self.bind(l1_addr_scrambler_list[pe_id], 'output', ico_list[pe_id], 'input')
+                    pe_id += 1
+            elif not fast_model:
+                # Use WireMaster & WireSlave
+                # Add fpu sequence buffer in between int core and fp core to issue instructions
+                if Xfrep:
+                    self.bind(self.int_cores[core_id], 'acc_req', fpu_sequencers[core_id], 'input')
+                    self.bind(fpu_sequencers[core_id], 'output', self.fp_cores[core_id], 'acc_req')
+                    self.bind(self.int_cores[core_id], 'acc_req_ready', fpu_sequencers[core_id], 'acc_req_ready')
+                    self.bind(fpu_sequencers[core_id], 'acc_req_ready_o', self.fp_cores[core_id], 'acc_req_ready')
+                else:
+                    # Comment out if we want to add sequencer
+                    self.bind(self.int_cores[core_id], 'acc_req', self.fp_cores[core_id], 'acc_req')
+                    self.bind(self.int_cores[core_id], 'acc_req_ready', self.fp_cores[core_id], 'acc_req_ready')
+
+                self.bind(self.fp_cores[core_id], 'acc_rsp', self.int_cores[core_id], 'acc_rsp')

--- a/pulp/mempool/mempool_tile.py
+++ b/pulp/mempool/mempool_tile.py
@@ -17,16 +17,12 @@
 # Author: Yichao Zhang (ETH Zurich) (yiczhang@iis.ee.ethz.ch)
 #         Yinrong Li (ETH Zurich) (yinrli@student.ethz.ch)
 
-import pulp.snitch.snitch_core as iss
 from pulp.mempool.hierarchical_cache import Hierarchical_cache
 import pulp.mempool.l1_subsystem as l1_subsystem
 import interco.router as router
 import gvsoc.systree as st
-from pulp.snitch.sequencer import Sequencer
 from pulp.mempool.l1_interconnect.l1_address_scrambler import L1AddressScrambler
-
-from pulp.cpu.iss.spatz_config import SpatzConfig
-from pulp.cpu.iss.spatz_mempool import SpatzMempool
+from pulp.cpu.iss.snitch_mempool import SnitchMempoolConfig, SnitchMempool
 
 class Tile(st.Component):
 
@@ -34,9 +30,6 @@ class Tile(st.Component):
         super().__init__(parent, name)
 
         [args, __] = parser.parse_known_args()
-
-        # Set it to true to swtich to snitch new fast model
-        fast_model = True
         use_spatz = nb_fus_per_core > 1
 
         ################################################################
@@ -47,16 +40,11 @@ class Tile(st.Component):
         nb_remote_sub_group_ports = nb_sub_groups_per_group - 1
         nb_tiles_per_sub_group = int((total_cores/nb_groups/nb_sub_groups_per_group)/nb_cores_per_tile)
         # global_tile_id = tile_id + group_id * nb_tiles_per_group
-        Xfrep = 0
         # stack_size_per_tile = 0x800
         mem_size = nb_cores_per_tile * bank_factor * nb_fus_per_core * 1024
 
-        # Snitch core complex
-        self.int_cores = []
-        self.fp_cores = []
-        bus_watchpoints = []
-        if Xfrep and not use_spatz:
-            fpu_sequencers = []
+        # core complex
+        self.cores = []
 
         ################################################################
         ##########              Design Components             ##########
@@ -95,23 +83,16 @@ class Tile(st.Component):
             core_global_id = group_id*nb_sub_groups_per_group*nb_tiles_per_sub_group*nb_cores_per_tile+sub_group_id*nb_tiles_per_sub_group*nb_cores_per_tile+tile_id*nb_cores_per_tile+core_id
 
             if use_spatz:
-                config = SpatzConfig(isa="rv32imafv", fetch_enable=False,
-                    boot_addr=0, hart_id=core_global_id,
-                    htif=False, nb_lanes=nb_fus_per_core, lane_width=4)
-                self.int_cores.append(SpatzMempool(self, f'pe{core_id}', config=config))
-
-            elif fast_model:
-                self.int_cores.append(iss.SnitchFast(self, f'pe{core_id}', isa="rv32imaf",
-                    core_id=core_global_id, htif=False, pulp_v2=True, wakeup_counter=True, nb_outstanding=8
-                ))
+                config = SnitchMempoolConfig(isa="rv32imafv", fetch_enable=False,
+                    boot_addr=0, hart_id=core_global_id, htif=False, nb_outstanding=8, 
+                    vector=True, nb_lanes=nb_fus_per_core, lane_width=4)
+                self.cores.append(SnitchMempool(self, f'pe{core_id}', config=config))
 
             else:
-                self.int_cores.append(iss.Snitch(self, f'pe{core_id}', isa="rv32imaf", htif=False, \
-                    core_id=core_global_id, pulp_v2=True))
-                self.fp_cores.append(iss.Snitch_fp_ss(self, f'fp_ss{core_id}', isa="rv32imaf", htif=False, \
-                    core_id=core_global_id, pulp_v2=True))
-                if Xfrep:
-                    fpu_sequencers.append(Sequencer(self, f'fpu_sequencer{core_id}', latency=0))
+                config = SnitchMempoolConfig(isa="rv32imaf", fetch_enable=False,
+                    boot_addr=0, hart_id=core_global_id, htif=False, nb_outstanding=8, 
+                    vector=False)
+                self.cores.append(SnitchMempool(self, f'pe{core_id}', config=config))
 
         ################################################################
         ##########               Design Bindings              ##########
@@ -164,28 +145,20 @@ class Tile(st.Component):
 
         # Sync barrier
         for core_id in range(0, nb_cores_per_tile):
-            self.bind(self, f'barrier_ack_{core_id}', self.int_cores[core_id], 'barrier_ack')
+            self.bind(self, f'barrier_ack_{core_id}', self.cores[core_id], 'barrier_ack')
 
         # Core Interconnections
         pe_id = 0
         for core_id in range(0, nb_cores_per_tile):
             # Icache
-            self.bind(self.int_cores[core_id], 'flush_cache_req', icache, 'flush')
-            self.bind(icache, 'flush_ack', self.int_cores[core_id], 'flush_cache_ack')
+            self.bind(self.cores[core_id], 'flush_cache_req', icache, 'flush')
+            self.bind(icache, 'flush_ack', self.cores[core_id], 'flush_cache_ack')
 
             # Snitch integer cores
-            self.bind(self.int_cores[core_id], 'data', l1_addr_scrambler_list[pe_id], 'input')
-            self.bind(self.int_cores[core_id], 'fetch', icache, 'input_%d' % core_id)
-            self.bind(self, 'loader_start', self.int_cores[core_id], 'fetchen')
-            self.bind(self, 'loader_entry', self.int_cores[core_id], 'bootaddr')
-
-            if not use_spatz and not fast_model:
-                # Snitch fp subsystems
-                # Pay attention to interactions and bandwidth between subsystem and tohost.
-                self.bind(self.fp_cores[core_id], 'data', l1_addr_scrambler_list[pe_id], 'input')
-                # FP subsystem doesn't fetch instructions from core->ico->memory, but from integer cores acc_req.
-                self.bind(self, 'loader_start', self.fp_cores[core_id], 'fetchen')
-                self.bind(self, 'loader_entry', self.fp_cores[core_id], 'bootaddr')
+            self.bind(self.cores[core_id], 'data', l1_addr_scrambler_list[pe_id], 'input')
+            self.bind(self.cores[core_id], 'fetch', icache, 'input_%d' % core_id)
+            self.bind(self, 'loader_start', self.cores[core_id], 'fetchen')
+            self.bind(self, 'loader_entry', self.cores[core_id], 'bootaddr')
             
             # Scrambler
             self.bind(l1_addr_scrambler_list[pe_id], 'output', ico_list[pe_id], 'input')
@@ -193,20 +166,6 @@ class Tile(st.Component):
 
             if use_spatz:
                 for port in range(0, nb_fus_per_core):
-                    self.bind(self.int_cores[core_id], f'vlsu_{port}', l1_addr_scrambler_list[pe_id], 'input')
+                    self.bind(self.cores[core_id], f'vlsu_{port}', l1_addr_scrambler_list[pe_id], 'input')
                     self.bind(l1_addr_scrambler_list[pe_id], 'output', ico_list[pe_id], 'input')
                     pe_id += 1
-            elif not fast_model:
-                # Use WireMaster & WireSlave
-                # Add fpu sequence buffer in between int core and fp core to issue instructions
-                if Xfrep:
-                    self.bind(self.int_cores[core_id], 'acc_req', fpu_sequencers[core_id], 'input')
-                    self.bind(fpu_sequencers[core_id], 'output', self.fp_cores[core_id], 'acc_req')
-                    self.bind(self.int_cores[core_id], 'acc_req_ready', fpu_sequencers[core_id], 'acc_req_ready')
-                    self.bind(fpu_sequencers[core_id], 'acc_req_ready_o', self.fp_cores[core_id], 'acc_req_ready')
-                else:
-                    # Comment out if we want to add sequencer
-                    self.bind(self.int_cores[core_id], 'acc_req', self.fp_cores[core_id], 'acc_req')
-                    self.bind(self.int_cores[core_id], 'acc_req_ready', self.fp_cores[core_id], 'acc_req_ready')
-
-                self.bind(self.fp_cores[core_id], 'acc_rsp', self.int_cores[core_id], 'acc_rsp')

--- a/terapool-spatz.py
+++ b/terapool-spatz.py
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2020 ETH Zurich and University of Bologna
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pulp.mempool.mempool_system import TerapoolSpatzSystem
+import gvsoc.runner as gvsoc
+
+GAPY_TARGET = True
+
+class Target(gvsoc.Target):
+
+    def __init__(self, parser, options):
+        super(Target, self).__init__(parser, options,
+            model=TerapoolSpatzSystem, description="TerapoolSpatzSystem")


### PR DESCRIPTION
Integrates Spatz into the Mempool model.

- Adds mempool-spatz, minpool-spatz, and terapool-spatz GAPY targets and corresponding system wrappers.

- Adds Spatz-based configuration with `SnitchMempool` model.

- Passes `nb_fus_per_core` throughout the Mempool hierarchy to distinguish between Snitch-only configuration and Spatz-based configuration with multiple functional units per core.

- Updates L1 memory sizing, bank counts, interleaving, address scramblers, PE ports, and shared icache sizing to account for Spatz lanes.