### PR TITLE
Add SnitchMempool core

### DIFF
--- a/cpu/iss_v2/include/cores/snitchmempool/irq_mempool.hpp
+++ b/cpu/iss_v2/include/cores/snitchmempool/irq_mempool.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 ETH Zurich, University of Bologna
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Authors: Germain Haugou (germain.haugou@gmail.com)
+
+#pragma once
+
+#include <cpu/iss_v2/include/irq/irq_riscv.hpp>
+
+// IrqRiscv whose wfi_handle consumes a SnitchMempool wake-up credit before sleeping.
+class IrqMempool : public IrqRiscv
+{
+public:
+    IrqMempool(Iss &iss) : IrqRiscv(iss) {}
+
+    void wfi_handle(iss_insn_t *insn);
+};

--- a/cpu/iss_v2/include/cores/snitchmempool/snitchmempool.hpp
+++ b/cpu/iss_v2/include/cores/snitchmempool/snitchmempool.hpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 ETH Zurich, University of Bologna
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Authors: Germain Haugou
+
+#pragma once
+
+#include <cpu/iss_v2/include/types.hpp>
+#include <cpu/iss_v2/include/insn.hpp>
+#include <cpu/iss_v2/include/csr.hpp>
+#if defined(CONFIG_GVSOC_ISS_USE_SPATZ)
+#include <cpu/iss_v2/include/vector.hpp>
+#include <cpu/iss_v2/include/cores/vector_unit/vector_unit.hpp>
+#endif
+
+class Iss;
+
+// Snitch arch for Mempool-style clusters: Snitch stack CSRs, a memory-mapped
+// barrier (wake on the barrier_ack port) and a wake-up counter for the
+// barrier_sync/WFI race. With CONFIG_GVSOC_ISS_USE_SPATZ it also carries the
+// Spatz vector unit.
+class SnitchMempool
+{
+public:
+    SnitchMempool(Iss &iss);
+
+    void start() {}
+    void stop() {}
+    void reset(bool active);
+
+#if defined(CONFIG_GVSOC_ISS_USE_SPATZ)
+    // Vector unit, identical to Spatz (vector config only).
+    Vu vu;
+#endif
+
+    // Consume a wake-up credit (from IrqMempool::wfi_handle); true if available.
+    inline bool wakeup_check();
+
+private:
+    static void barrier_sync(vp::Block *__this, bool value);
+
+    Iss &iss;
+
+    vp::reg_8 wakeup;
+
+    // Snitch stack CSRs 0x7d0-0x7d2 (plain storage; see the .cpp).
+    CsrReg stack_conf;
+    CsrReg stack_start;
+    CsrReg stack_end;
+    vp::WireSlave<bool> barrier_ack_itf;
+
+    vp::Trace trace;
+};
+
+inline bool SnitchMempool::wakeup_check()
+{
+    if (this->wakeup.get())
+    {
+        this->wakeup.dec(1);
+        return true;
+    }
+    return false;
+}

--- a/cpu/iss_v2/src/cores/snitchmempool/irq_mempool.cpp
+++ b/cpu/iss_v2/src/cores/snitchmempool/irq_mempool.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 ETH Zurich, University of Bologna
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Authors: Germain Haugou (germain.haugou@gmail.com)
+
+#include <cpu/iss_v2/include/iss.hpp>
+
+void IrqMempool::wfi_handle(iss_insn_t *insn)
+{
+    // Consume a banked barrier wake-up if any; otherwise sleep.
+    if (this->iss.arch.wakeup_check())
+    {
+        return;
+    }
+
+    this->iss.exec.wfi.set(true);
+    this->iss.exec.wfi_start = this->iss.clock.get_cycles();
+    this->iss.exec.retain_inc();
+    this->wfi_entry = this->iss.exec.insn_hold(insn);
+}

--- a/cpu/iss_v2/src/cores/snitchmempool/snitchmempool.cpp
+++ b/cpu/iss_v2/src/cores/snitchmempool/snitchmempool.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 ETH Zurich, University of Bologna
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Authors: Germain Haugou
+
+#include <cpu/iss_v2/include/iss.hpp>
+
+SnitchMempool::SnitchMempool(Iss &iss)
+#if defined(CONFIG_GVSOC_ISS_USE_SPATZ)
+: vu(iss), iss(iss)
+#else
+: iss(iss)
+#endif
+{
+    this->iss.traces.new_trace("snitch_mempool", &this->trace, vp::DEBUG);
+
+    this->iss.new_reg("wakeup", &this->wakeup, 0);
+
+    this->barrier_ack_itf.set_sync_meth(&SnitchMempool::barrier_sync);
+    this->iss.new_slave_port("barrier_ack", &this->barrier_ack_itf, (vp::Block *)this);
+
+    // Snitch stack CSRs 0x7d0-0x7d2 (CSR_STACK_CONF/START/END)
+    this->iss.csr.declare_csr(&this->stack_conf,  "stack_conf",  0x7d0);
+    this->iss.csr.declare_csr(&this->stack_start, "stack_start", 0x7d1);
+    this->iss.csr.declare_csr(&this->stack_end,   "stack_end",   0x7d2);
+}
+
+void SnitchMempool::reset(bool active)
+{
+#if defined(CONFIG_GVSOC_ISS_USE_SPATZ)
+    this->vu.reset(active);
+#endif
+    // The wake-up counter is reset through new_reg.
+}
+
+void SnitchMempool::barrier_sync(vp::Block *__this, bool value)
+{
+    SnitchMempool *_this = (SnitchMempool *)__this;
+
+    if (value)
+    {
+        if (_this->iss.exec.wfi.get())
+        {
+            // Already sleeping on WFI: wake it (release the parked InsnEntry).
+            _this->iss.exec.wfi.set(false);
+            _this->iss.exec.retain_dec();
+            _this->iss.exec.insn_terminate(_this->iss.irq.wfi_entry);
+        }
+        else
+        {
+            // Wake-up beat the WFI: bank a credit for the next WFI.
+            _this->wakeup.inc(1);
+        }
+    }
+}

--- a/pulp/cpu/iss/snitch_mempool.py
+++ b/pulp/cpu/iss/snitch_mempool.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2026 ETH Zurich, University of Bologna
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Authors: Germain Haugou (germain.haugou@gmail.com)
+
+"""Snitch core for Mempool-style clusters: Snitch stack CSRs, a memory-mapped
+barrier (wake on the barrier_ack port) and a wake-up counter. config.vector
+folds in the Spatz vector unit; config.lsu_v2 picks the io_v2 LSU (independent
+of the vector unit)."""
+
+from typing_extensions import override
+
+import cpu.iss.isa_gen.isa_riscv_gen
+import gvsoc.systree
+import pulp.ara.ara_v2
+from config_tree import cfg_field
+from cpu.iss.isa_gen.isa_gen import Isa
+from cpu.iss.isa_gen.isa_pulpv2 import PulpV2
+from cpu.iss.isa_gen.isa_smallfloats import Xf16, Xf16alt, Xf8, Xfaux, XfvecSnitch
+from cpu.iss_v2.riscv import (Arch, ExecInOrder, IssModule, Lsu, LsuV2, Offload,
+                              PrefetchSingleLine, Regfile, RiscvCommon)
+from cpu.iss_v2.riscv_config import RiscvConfig
+from gvsoc.systree import Component
+from pulp.snitch.snitch_isa import Xdma
+
+
+class SnitchMempoolConfig(RiscvConfig):
+    nb_outstanding: int = cfg_field(default=1, dump=True,
+        desc="Max outstanding LSU requests.")
+    zfinx: bool = cfg_field(default=True, dump=True,
+        desc="Single-precision FP on the integer register file (Zfinx).")
+    lsu_v2: bool = cfg_field(default=False, dump=True,
+        desc="Use the io_v2 LSU variant (works with or without the vector unit).")
+    vector: bool = cfg_field(default=False, dump=True,
+        desc="Fold in the Spatz vector unit; False = scalar Snitch.")
+    vlen: int = cfg_field(default=512, dump=True, desc="RISCV VLEN in bits (vector only).")
+    nb_lanes: int = cfg_field(default=4, dump=True, desc="Number of vector lanes (vector only).")
+    lane_width: int = cfg_field(default=8, dump=True,
+        desc="Vector lane width in bytes (vector only).")
+
+
+class ArchSnitchMempool(Arch):
+    """Arch module selecting the SnitchMempool C++ core class."""
+
+    def __init__(self):
+        super().__init__(
+            class_name='SnitchMempool',
+            source='cpu/iss_v2/src/cores/snitchmempool/snitchmempool.cpp')
+
+    @override
+    def gen(self, iss: RiscvCommon):
+        iss.isa.add_define('CONFIG_GVSOC_ISS_ARCH', 'SnitchMempool')
+        iss.isa.add_include(
+            '<cpu/iss_v2/include/cores/snitchmempool/snitchmempool.hpp>')
+        iss.add_sources([self.source])
+
+
+class IrqMempool(IssModule):
+    """IrqRiscv whose wfi_handle consults the wake-up counter before sleeping."""
+
+    @override
+    def gen(self, iss: RiscvCommon):
+        iss.isa.add_define('CONFIG_GVSOC_ISS_IRQ', 'IrqMempool')
+        iss.isa.add_define('CONFIG_GVSOC_ISS_RISCV_EXCEPTIONS', 1)
+        iss.isa.add_include(
+            '<cpu/iss_v2/include/cores/snitchmempool/irq_mempool.hpp>')
+        iss.add_sources([
+            'cpu/iss_v2/src/irq/irq_riscv.cpp',
+            'cpu/iss_v2/src/cores/snitchmempool/irq_mempool.cpp',
+        ])
+
+
+_isa_instances: dict[str, Isa] = {}
+
+
+class SnitchMempool(RiscvCommon):
+    """Snitch core with stack CSRs, a memory-mapped barrier and a wake-up
+    counter. config.vector adds the Spatz vector unit; config.lsu_v2 picks the
+    io_v2 LSU. CSR and irq/wake-up behaviour is the scalar Snitch's in both."""
+
+    def __init__(self, parent: Component, name: str, config: SnitchMempoolConfig):
+
+        cache_key = ('vector_' if config.vector else 'scalar_') + config.isa
+        isa_instance: Isa | None = _isa_instances.get(cache_key)
+
+        if isa_instance is None:
+            if config.vector:
+                extensions = [Xdma(), Xf16(), Xf16alt(), Xf8(), XfvecSnitch(), Xfaux()]
+            else:
+                extensions = [Xf16(), Xf16alt(), Xf8(), XfvecSnitch(), Xfaux(),
+                              PulpV2(hwloop=False, elw=False)]
+            isa_instance = cpu.iss.isa_gen.isa_riscv_gen.RiscvIsa(
+                'snitch_mempool_' + cache_key, config.isa, extensions=extensions)
+            if config.vector:
+                pulp.ara.ara_v2.extend_isa(isa_instance)
+            _isa_instances[cache_key] = isa_instance
+
+        modules: dict[str, IssModule] = {
+            'arch': ArchSnitchMempool(),
+            'exec': ExecInOrder(scoreboard=True),
+            'regfile': Regfile(scoreboard=True),
+            'prefetch': PrefetchSingleLine(),
+            'irq': IrqMempool(),
+            'lsu': (LsuV2 if config.lsu_v2 else Lsu)(nb_outstanding=config.nb_outstanding),
+        }
+        if config.vector:
+            modules['offload'] = Offload()
+
+        super().__init__(parent, name, config=config, isa=isa_instance,
+            modules=modules, zfinx=config.zfinx)
+
+        if config.vector:
+            self._lsu_v2 = config.lsu_v2
+            pulp.ara.ara_v2.attach(self, config.vlen, nb_lanes=config.nb_lanes,
+                use_spatz=True, lane_width=config.lane_width, vlsu_v2=config.lsu_v2)
+
+    def o_VLSU(self, port: int, itf: gvsoc.systree.SlaveItf):
+        self.itf_bind(f'vlsu_{port}', itf,
+            signature='io_v2' if getattr(self, '_lsu_v2', False) else 'io')


### PR DESCRIPTION
This is a new Snitch core aiming at replacing the current SnitchFast in the MemPool and TeraNoC models. It is build based on SpatzMempool, with several custom CSRs added and wakeup behavior calibrated. This model covers both Snitch-only and Snitch-Spatz configs.