### PR TITLE
Add VCD output for `light_redmule` + fix hwpe-ctrl interface for `light_redmule`

### DIFF
--- a/pulp/idma/be/idma_be.cpp
+++ b/pulp/idma/be/idma_be.cpp
@@ -27,7 +27,8 @@ IDmaBe::IDmaBe(vp::Component *idma, IdmaTransferProducer *me,
     IdmaBeConsumer *loc_be_read, IdmaBeConsumer *loc_be_write,
     IdmaBeConsumer *ext_be_read, IdmaBeConsumer *ext_be_write)
 :   Block(idma, "be"),
-    fsm_event(this, &IDmaBe::fsm_handler)
+    fsm_event(this, &IDmaBe::fsm_handler),
+    be_state(*this, "be_state", 32, true, BE_IDLE)
 {
     // Middle-end and backend protocols will be used later for interaction
     this->me = me;
@@ -72,6 +73,7 @@ void IDmaBe::enqueue_transfer(IdmaTransfer *transfer)
     this->current_transfer_dst = transfer->dst;
     this->current_transfer_src_be = this->get_be_consumer(transfer->src, transfer->size, true);
     this->current_transfer_dst_be = this->get_be_consumer(transfer->dst, transfer->size, false);
+    this->be_state.set(BE_ACTIVE);
 
     // Trigger FSM
     this->fsm_event.enqueue();
@@ -132,6 +134,8 @@ void IDmaBe::fsm_handler(vp::Block *__this, vp::ClockEvent *event)
 
         if (_this->current_transfer_size == 0)
         {
+            _this->be_state.set(BE_IDLE);
+
             // In case the transfer is finished, the middle-end may push a new one
             _this->me->update();
         }

--- a/pulp/idma/be/idma_be.hpp
+++ b/pulp/idma/be/idma_be.hpp
@@ -21,10 +21,19 @@
 #pragma once
 
 #include <vp/vp.hpp>
+#include <vp/register.hpp>
 #include "../idma.hpp"
 #include "vp/itf/io.hpp"
 
 class IdmaTransferProducer;
+
+
+// Backend FSM state, exposed as a trace event ("be_state") for profiling.
+enum IDmaBeState
+{
+    BE_IDLE,    // no transfer being processed (current_transfer_size == 0)
+    BE_ACTIVE,  // a transfer is being split into bursts and delegated to backend protocols
+};
 
 
 
@@ -244,6 +253,8 @@ private:
     vp::Trace trace;
     // Block FSM event, used to trigger all checks after something has been updated
     vp::ClockEvent fsm_event;
+    // FSM state (see IDmaBeState), traced for profiling
+    vp::Register<uint32_t> be_state;
     // Current transfer being processed. This transfer is kept active until all bursts
     // have been delegated to backend protocols.
     IdmaTransfer *current_transfer;

--- a/pulp/idma/me/idma_me_2d.cpp
+++ b/pulp/idma/me/idma_me_2d.cpp
@@ -24,7 +24,8 @@
 
 IDmaMe2D::IDmaMe2D(vp::Component *idma, IdmaTransferProducer *fe, IdmaTransferConsumer *be)
 :   Block(idma, "me"),
-    fsm_event(this, &IDmaMe2D::fsm_handler)
+    fsm_event(this, &IDmaMe2D::fsm_handler),
+    me_state(*this, "me_state", 32, true, ME_IDLE)
 {
     // Frontend and backend will be used later for interaction
     this->fe = fe;
@@ -120,6 +121,8 @@ void IDmaMe2D::fsm_handler(vp::Block *__this, vp::ClockEvent *event)
         {
             _this->current_reps = 1;
         }
+
+        _this->me_state.set(ME_DECOMPOSING);
     }
 
     // Check if we can extract a burst from the current transfer
@@ -144,6 +147,7 @@ void IDmaMe2D::fsm_handler(vp::Block *__this, vp::ClockEvent *event)
             // And remove it
             _this->current_transfer = NULL;
             _this->transfer_queue.pop();
+            _this->me_state.set(ME_IDLE);
 
             // Update frontend in case it has a transfer to queue
             _this->fe->update();

--- a/pulp/idma/me/idma_me_2d.hpp
+++ b/pulp/idma/me/idma_me_2d.hpp
@@ -21,8 +21,16 @@
 #pragma once
 
 #include <vp/vp.hpp>
+#include <vp/register.hpp>
 #include "../idma.hpp"
 
+
+// Middle-end FSM state, exposed as a trace event ("me_state") for profiling.
+enum IDmaMeState
+{
+    ME_IDLE,         // no current transfer being decomposed
+    ME_DECOMPOSING,  // splitting the current transfer into bursts for the backend
+};
 
 
 /**
@@ -67,6 +75,8 @@ private:
     std::queue<IdmaTransfer *> transfer_queue;
     // Block FSM event, used to trigger all checks after something has been updated
     vp::ClockEvent fsm_event;
+    // FSM state (see IDmaMeState), traced for profiling
+    vp::Register<uint32_t> me_state;
     // Current transfer being processed
     IdmaTransfer *current_transfer;
     // Current source address of the current transfer, updated each time a burst is sent

--- a/pulp/light_redmule/light_redmule.cpp
+++ b/pulp/light_redmule/light_redmule.cpp
@@ -36,6 +36,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <math.h>
+#include <vp/register.hpp>
 
 #include <cpu/iss/include/offload.hpp>
 #include <cpu/iss/flexfloat/flexfloat.h>
@@ -136,7 +137,8 @@ public:
     vp::IoReq *         redmule_query;
     vp::IoReq*          tcdm_req;
     vp::ClockEvent *    fsm_event;
-    vp::reg_32          state;
+    vp::Register<uint32_t>  reg_fsm_state;
+    vp::Register<uint32_t>  reg_busy;
     uint32_t            tcdm_block_total;
     uint32_t            fsm_counter;
     uint32_t            fsm_timestamp;
@@ -220,7 +222,9 @@ extern "C" vp::Component *gv_new(vp::ComponentConf &config)
 }
 
 LightRedmule::LightRedmule(vp::ComponentConf &config)
-    : vp::Component(config)
+    : vp::Component(config),
+    reg_fsm_state(*this, "fsm_state", 32, true, IDLE),
+    reg_busy(*this, "busy", 1, true, 0)
 {
     //Initialize interface
     this->traces.new_trace("trace", &this->trace, vp::DEBUG);
@@ -308,7 +312,8 @@ LightRedmule::LightRedmule(vp::ComponentConf &config)
     this->z_buffer_previos  = new uint8_t [this->LOCAL_BUFFER_H * this->LOCAL_BUFFER_W * this->elem_size];
 
     //Initialize FSM
-    this->state.set(IDLE);
+    this->reg_fsm_state.set(IDLE);
+    this->reg_busy.set(0);
     this->redmule_query     = NULL;
     this->tcdm_req          = this->tcdm_itf.req_new(0, 0, 0, 0);
     this->fsm_event         = this->event_new(&LightRedmule::fsm_handler);
@@ -563,7 +568,7 @@ void LightRedmule::process_iter_instruction(){
     uint32_t buffer_w_byte = this->ce_width * (this->ce_pipe + 1) * this->elem_size;
 
     uint32_t _k = this->iter_k + 1;
-    if ((_k == this->x_row_tiles) || this->state.get() == PRELOAD)
+    if ((_k == this->x_row_tiles) || this->reg_fsm_state.get() == PRELOAD)
     {
         _k = 0;
     }
@@ -574,7 +579,7 @@ void LightRedmule::process_iter_instruction(){
     uint32_t w_cutoff = w_leftover_byte < buffer_w_byte ? w_leftover_byte : buffer_w_byte;
 
     uint32_t _j = this->iter_j + 1;
-    if ((_j == this->z_row_tiles) || this->state.get() == PRELOAD)
+    if ((_j == this->z_row_tiles) || this->reg_fsm_state.get() == PRELOAD)
     {
         _j = 0;
     }
@@ -828,7 +833,7 @@ void LightRedmule::offload_sync(vp::Block *__this, IssOffloadInsn<uint32_t> *ins
     {
         case 0b0001011:
         {
-            if (_this->state.get() == IDLE) {
+            if (_this->reg_fsm_state.get() == IDLE) {
                 insn->granted = true; //here we always grant the core as it is just a configuration
                 _this->m_size = insn->arg_a & 0xFFFF;
                 _this->n_size = insn->arg_b;
@@ -839,7 +844,7 @@ void LightRedmule::offload_sync(vp::Block *__this, IssOffloadInsn<uint32_t> *ins
         }
         case 0b0101011:
         {
-            if (_this->state.get() == IDLE)
+            if (_this->reg_fsm_state.get() == IDLE)
             {
                 insn->granted = true; //as soon as the operations is triggered we deassert the core
                 _this->x_addr = insn->arg_a;
@@ -864,7 +869,8 @@ void LightRedmule::offload_sync(vp::Block *__this, IssOffloadInsn<uint32_t> *ins
                 _this->init_redmule_meta_data();
 
                 //Trigger FSM
-                _this->state.set(PRELOAD);
+                _this->reg_fsm_state.set(PRELOAD);
+                _this->reg_busy.set(1);
                 _this->tcdm_block_total = _this->get_preload_access_block_number();
                 _this->fsm_counter      = 0;
                 _this->fsm_timestamp    = 0;
@@ -894,7 +900,7 @@ vp::IoReqStatus LightRedmule::req(vp::Block *__this, vp::IoReq *req)
         uint32_t value = *(uint32_t *)data;
         switch (offset) {
             case 0x00: {
-                if ((_this->redmule_query == NULL) && (_this->state.get() == IDLE)) {
+                if ((_this->redmule_query == NULL) && (_this->reg_fsm_state.get() == IDLE)) {
                     /************************
                     *  Synchronize Trigger  *
                     ************************/
@@ -912,7 +918,8 @@ vp::IoReqStatus LightRedmule::req(vp::Block *__this, vp::IoReq *req)
                     
 
                     //Trigger FSM
-                    _this->state.set(PRELOAD);
+                    _this->reg_fsm_state.set(PRELOAD);
+                    _this->reg_busy.set(1);
                     _this->tcdm_block_total = _this->get_preload_access_block_number();
                     _this->fsm_counter      = 0;
                     _this->fsm_timestamp    = 0;
@@ -969,7 +976,7 @@ vp::IoReqStatus LightRedmule::req(vp::Block *__this, vp::IoReq *req)
                 break;
             case 0x0C: {
                 int32_t done_id_r;
-                if ((_this->redmule_query == NULL) && (_this->state.get() == IDLE)) {
+                if ((_this->redmule_query == NULL) && (_this->reg_fsm_state.get() == IDLE)) {
                     done_id_r =  0x00;
                     memcpy((void *)data, (void *)&done_id_r, size);
                 }
@@ -1002,7 +1009,7 @@ vp::IoReqStatus LightRedmule::req_v2(vp::Block *__this, vp::IoReq *req)
         uint32_t value = *(uint32_t *)data;
         switch (offset) {
             case 0x00: {
-                if ((_this->redmule_query == NULL) && (_this->state.get() == IDLE)) {
+                if ((_this->redmule_query == NULL) && (_this->reg_fsm_state.get() == IDLE)) {
                     /************************
                     *  Synchronize Trigger  *
                     ************************/
@@ -1020,7 +1027,8 @@ vp::IoReqStatus LightRedmule::req_v2(vp::Block *__this, vp::IoReq *req)
                     
 
                     //Trigger FSM
-                    _this->state.set(PRELOAD);
+                    _this->reg_fsm_state.set(PRELOAD);
+                    _this->reg_busy.set(1);
                     _this->tcdm_block_total = _this->get_preload_access_block_number();
                     _this->fsm_counter      = 0;
                     _this->fsm_timestamp    = 0;
@@ -1081,7 +1089,7 @@ vp::IoReqStatus LightRedmule::req_v2(vp::Block *__this, vp::IoReq *req)
                 break;
             case 0x0C: {
                 int32_t done_id_r;
-                if ((_this->redmule_query == NULL) && (_this->state.get() == IDLE)) {
+                if ((_this->redmule_query == NULL) && (_this->reg_fsm_state.get() == IDLE)) {
                     done_id_r =  0x00;
                     memcpy((void *)data, (void *)&done_id_r, size);
                 }
@@ -1099,7 +1107,7 @@ vp::IoReqStatus LightRedmule::req_v2(vp::Block *__this, vp::IoReq *req)
     return vp::IO_REQ_OK;
 }
 
-    // if ((is_write == 0) && (offset == 32) && (_this->redmule_query == NULL) && (_this->state.get() == IDLE))
+    // if ((is_write == 0) && (offset == 32) && (_this->redmule_query == NULL) && (_this->reg_fsm_state.get() == IDLE))
     // {
     //     /************************
     //     *  Synchronize Trigger  *
@@ -1129,7 +1137,7 @@ vp::IoReqStatus LightRedmule::req_v2(vp::Block *__this, vp::IoReq *req)
     //     _this->redmule_query = req;
     //     return vp::IO_REQ_PENDING;
 
-    // } else if ((is_write == 0) && (offset == 36) && (_this->state.get() == IDLE)){
+    // } else if ((is_write == 0) && (offset == 36) && (_this->reg_fsm_state.get() == IDLE)){
     //     /*************************
     //     *  Asynchronize Trigger  *
     //     *************************/
@@ -1154,7 +1162,7 @@ vp::IoReqStatus LightRedmule::req_v2(vp::Block *__this, vp::IoReq *req)
     //     _this->compute_able     = 0;
     //     _this->event_enqueue(_this->fsm_event, 1);
 
-    // } else if ((is_write == 0) && (offset == 40) && (_this->redmule_query == NULL) && (_this->state.get() != IDLE)){
+    // } else if ((is_write == 0) && (offset == 40) && (_this->redmule_query == NULL) && (_this->reg_fsm_state.get() != IDLE)){
     //     /*************************
     //     *  Asynchronize Waiting  *
     //     *************************/
@@ -1172,7 +1180,7 @@ void LightRedmule::fsm_handler(vp::Block *__this, vp::ClockEvent *event)
 
     _this->fsm_timestamp += 1;
 
-    switch (_this->state.get()) {
+    switch (_this->reg_fsm_state.get()) {
         case IDLE:
             _this->done.sync(false); //clear irq
             break;
@@ -1232,7 +1240,8 @@ void LightRedmule::fsm_handler(vp::Block *__this, vp::ClockEvent *event)
                 _this->tcdm_block_total = _this->get_routine_access_block_number();
                 _this->fsm_counter      = 0;
                 _this->fsm_timestamp    = 0;
-                _this->state.set(ROUTINE);
+                _this->reg_fsm_state.set(ROUTINE);
+                _this->reg_busy.set(1);
 
                 //Forward YZ at Preload->Routine if Compute Enabled
                 if (_this->compute_able != 0)
@@ -1241,7 +1250,8 @@ void LightRedmule::fsm_handler(vp::Block *__this, vp::ClockEvent *event)
                     _this->process_iter_instruction();
                 }
             } else {
-                _this->state.set(PRELOAD);
+                _this->reg_fsm_state.set(PRELOAD);
+                _this->reg_busy.set(1);
             }
 
             _this->event_enqueue(_this->fsm_event, 1);
@@ -1332,16 +1342,19 @@ void LightRedmule::fsm_handler(vp::Block *__this, vp::ClockEvent *event)
                 if (_this->next_iteration() == 0)
                 {
                     _this->tcdm_block_total = _this->get_routine_access_block_number();
-                    _this->state.set(ROUTINE);
+                    _this->reg_fsm_state.set(ROUTINE);
+                    _this->reg_busy.set(1);
                 } else {
                     _this->tcdm_block_total = _this->get_storing_access_block_number();
-                    _this->state.set(STORING);
+                    _this->reg_fsm_state.set(STORING);
+                    _this->reg_busy.set(1);
                     latency += _this->get_routine_to_storing_latency();
                 }
 
                 _this->event_enqueue(_this->fsm_event, latency);
             } else {
-                _this->state.set(ROUTINE);
+                _this->reg_fsm_state.set(ROUTINE);
+                _this->reg_busy.set(1);
                 _this->event_enqueue(_this->fsm_event, 1);
             }
 
@@ -1402,7 +1415,8 @@ void LightRedmule::fsm_handler(vp::Block *__this, vp::ClockEvent *event)
                 _this->tcdm_block_total = 0;
                 _this->fsm_counter      = 0;
                 _this->fsm_timestamp    = 0;
-                _this->state.set(FINISHED);
+                _this->reg_fsm_state.set(FINISHED);
+                _this->reg_busy.set(1);
                 _this->event_enqueue(_this->fsm_event, 1);
 
                 //report
@@ -1418,7 +1432,8 @@ void LightRedmule::fsm_handler(vp::Block *__this, vp::ClockEvent *event)
                 _this->trace.msg("[LightRedmule] Finished : %0d ns ---> %0d ns | period = %0d ns (%0d cyc) | uti = %0.3f | runtime = %0d ns | GEMM id = %0d | FMT = %0d | M-N-K = %0d-%0d-%0d | X-W-Y = 0x%5x-0x%5x-0x%5x\n",
                     start_time_ns, end_time_ns, period_ns, period_clk, period_uti, _this->total_runtime, _this->num_matmul, _this->compute_able, _this->m_size, _this->n_size, _this->k_size, _this->x_addr, _this->w_addr, _this->y_addr);
             } else {
-                _this->state.set(STORING);
+                _this->reg_fsm_state.set(STORING);
+                _this->reg_busy.set(1);
                 _this->event_enqueue(_this->fsm_event, 1);
             }
             break;
@@ -1428,14 +1443,16 @@ void LightRedmule::fsm_handler(vp::Block *__this, vp::ClockEvent *event)
             if (_this->redmule_query == NULL)
             {
                 _this->done.sync(true); //send interrupt
-                _this->state.set(IDLE);
+                _this->reg_fsm_state.set(IDLE);
+                _this->reg_busy.set(0);
                 // IssOffloadInsnGrant<uint32_t> offload_grant = {
                 //     .result=0x0
                 // };
                 // _this->offload_grant_itf.sync(&offload_grant);
                 _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule][FINISHED] GRANT core and Wait for query!\n");
             } else {
-                _this->state.set(ACKNOWLEDGE);
+                _this->reg_fsm_state.set(ACKNOWLEDGE);
+                _this->reg_busy.set(1);
             }
             _this->event_enqueue(_this->fsm_event, 1);
             break;
@@ -1444,7 +1461,8 @@ void LightRedmule::fsm_handler(vp::Block *__this, vp::ClockEvent *event)
             _this->redmule_query->get_resp_port()->resp(_this->redmule_query);
             _this->redmule_query = NULL;
             _this->done.sync(true); //send interrupt
-            _this->state.set(IDLE);
+            _this->reg_fsm_state.set(IDLE);
+            _this->reg_busy.set(0);
             // IssOffloadInsnGrant<uint32_t> offload_grant = {
             //     .result=0x0
             // };
@@ -1454,7 +1472,7 @@ void LightRedmule::fsm_handler(vp::Block *__this, vp::ClockEvent *event)
             break;
         }
         default:
-            _this->trace.fatal("[LightRedmule] INVALID RedMule Status: %d\n", _this->state);
+            _this->trace.fatal("[LightRedmule] INVALID RedMule Status: %d\n", _this->reg_fsm_state.get());
     }
 }
 

--- a/pulp/light_redmule/light_redmule.cpp
+++ b/pulp/light_redmule/light_redmule.cpp
@@ -15,9 +15,10 @@
  */
 
 /*
- * Authors: Chi     Zhang, ETH Zurich (chizhang@iis.ee.ethz.ch)
-            Lorenzo Zuolo, Chips-IT   (lorenzo.zuolo@chips.it)
-            Alex Marchioni, Chips-IT   (alex.marchioni@chips.it)
+ * Authors: Chi Zhang,       ETH Zurich                       chizhang@iis.ee.ethz.ch
+            Lorenzo Zuolo,   Chips-IT                         lorenzo.zuolo@chips.it
+            Alex Marchioni,  Chips-IT                         alex.marchioni@chips.it
+            Francesco Conti, University of Bologna & Chips-IT f.conti@unibo.it
  * Note:
  *      Here we only support (No Compute/ INT16 / UINT16 / FP16 ) for matrix multiply
  */
@@ -106,6 +107,12 @@ public:
 
     uint32_t op_foramt_parser(uint32_t op_format);
 
+    // HWPE control-register protocol (ACQUIRE / COMMIT_TRIGGER / SOFT_CLEAR)
+    int32_t  acquire();
+    void     commit(bool start);
+    void     start_next_job();
+    void     soft_clear(uint32_t value);
+
     vp::IoReqStatus send_tcdm_req();
     void init_redmule_meta_data();
     uint32_t tmp_next_addr();
@@ -147,6 +154,22 @@ public:
     int64_t             cycle_start;
     int64_t             total_runtime;
     int64_t             num_matmul;
+
+    //HWPE job queue (depth 2, double-buffered)
+    uint8_t             job_id_counter;   //wraps at 256
+    int                 job_state;        //0 = free to acquire, -2 = acquired-not-committed
+    int                 job_pending;      //0..2 committed-but-not-finished jobs
+    int                 cxt_cfg_ptr;      //context slot software is configuring
+    int                 cxt_use_ptr;      //context slot the FSM is executing
+    int                 cxt_job_id[2];    //job id per context slot, -1 = empty
+    int                 running_job_id;   //current/last running job id, -1 = none yet
+    uint32_t            cxt_m_size[2];
+    uint32_t            cxt_n_size[2];
+    uint32_t            cxt_k_size[2];
+    uint32_t            cxt_x_addr[2];
+    uint32_t            cxt_w_addr[2];
+    uint32_t            cxt_y_addr[2];
+    uint32_t            cxt_compute_able[2];
 
     //redmule configuration
     uint32_t            tcdm_bank_width;
@@ -324,7 +347,26 @@ LightRedmule::LightRedmule(vp::ComponentConf &config)
     this->cycle_start       = 0;
     this->total_runtime     = 0;
     this->num_matmul        = 0;
-    
+
+    //Initialize HWPE job queue
+    this->job_id_counter    = 0;
+    this->job_state         = 0;
+    this->job_pending       = 0;
+    this->cxt_cfg_ptr       = 0;
+    this->cxt_use_ptr       = 0;
+    this->cxt_job_id[0]     = -1;
+    this->cxt_job_id[1]     = -1;
+    this->running_job_id    = -1;
+    for (int i = 0; i < 2; i++) {
+        this->cxt_m_size[i]       = 0;
+        this->cxt_n_size[i]       = 0;
+        this->cxt_k_size[i]       = 0;
+        this->cxt_x_addr[i]       = 0;
+        this->cxt_w_addr[i]       = 0;
+        this->cxt_y_addr[i]       = 0;
+        this->cxt_compute_able[i] = 0;
+    }
+
     this->trace.msg("[LightRedmule] Model Initialization Done!\n");
 }
 
@@ -883,8 +925,129 @@ void LightRedmule::offload_sync(vp::Block *__this, IssOffloadInsn<uint32_t> *ins
     }
 }
 
-//This is a very basic reg-if tested and suited to work with MAGIA workloads.
-//Job queueing and full register mapping will be added in the future. 
+/************************************************************
+*  HWPE control-register protocol (ACQUIRE / COMMIT_TRIGGER  *
+*  / STATUS / RUNNING_JOB / SOFT_CLEAR), depth-2 job queue    *
+************************************************************/
+
+//ACQUIRE (0x04, read): assign a new job id and lock the controller
+int32_t LightRedmule::acquire()
+{
+    if (this->job_state != 0) {
+        //Already acquired, not yet committed: re-return the pending id
+        //(checked first to match hwpe_ctrl_target.sv ACQUIRE-state priority over queue-full)
+        return this->job_state;
+    } else if (this->job_pending == 2) {
+        //Queue full
+        return -1;
+    } else {
+        //Free to acquire and room in the queue: hand out a new id
+        int32_t id = (int32_t) this->job_id_counter++;
+        this->cxt_job_id[this->cxt_cfg_ptr] = id;
+        this->job_state = -2;
+        return id;
+    }
+}
+
+//COMMIT_TRIGGER write (ct == 0 commit+start, ct == 1 commit-only)
+void LightRedmule::commit(bool start)
+{
+    if (this->job_state == 0) {
+        //For callers that (improerly) write TRIGGER directly without ever
+        //reading ACQUIRE, the real HW behavior is to not advance the job
+        //id counter, but only the running job counter (which counts retired
+        //jobs). We mirror that here.
+        if (this->job_pending < 2) {
+            this->cxt_job_id[this->cxt_cfg_ptr] = (int32_t) this->job_id_counter;
+            this->job_state = -2;
+        }
+    }
+    if (this->job_state != -2) {
+        //Queue full: drop
+        this->trace.msg(vp::Trace::LEVEL_WARNING,"[LightRedmule] COMMIT_TRIGGER dropped: job queue full (job_pending=%d)\n", this->job_pending);
+        return;
+    }
+
+    //Commit: unlock, queue the job, flip the config pointer
+    this->job_pending++;
+    this->job_state = 0;
+    this->cxt_cfg_ptr = 1 - this->cxt_cfg_ptr;
+
+    if (start && (this->reg_fsm_state.get() == IDLE)) {
+        this->start_next_job();
+    }
+}
+
+//Load the queued job in cxt_use_ptr and kick off the FSM (IDLE -> PRELOAD)
+void LightRedmule::start_next_job()
+{
+    //Load context
+    this->m_size         = this->cxt_m_size[this->cxt_use_ptr];
+    this->n_size         = this->cxt_n_size[this->cxt_use_ptr];
+    this->k_size         = this->cxt_k_size[this->cxt_use_ptr];
+    this->x_addr         = this->cxt_x_addr[this->cxt_use_ptr];
+    this->w_addr         = this->cxt_w_addr[this->cxt_use_ptr];
+    this->y_addr         = this->cxt_y_addr[this->cxt_use_ptr];
+    this->z_addr         = this->y_addr;
+    this->compute_able   = this->cxt_compute_able[this->cxt_use_ptr];
+    this->elem_size      = (this->compute_able < 4) ? 2 : 1;
+    this->running_job_id = this->cxt_job_id[this->cxt_use_ptr];
+
+    //Sanity Check
+    this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] redmule configuration (M-N-K): %d, %d, %d. Compute able is %d\n", this->m_size, this->n_size, this->k_size, this->compute_able);
+    if ((this->m_size == 0)||(this->n_size == 0)||(this->k_size == 0))
+    {
+        this->trace.fatal("[LightRedmule] INVALID redmule configuration (M-N-K): %d, %d, %d\n", this->m_size, this->n_size, this->k_size);
+        return;
+    }
+
+    //Initilaize redmule meta data
+    this->init_redmule_meta_data();
+
+    //Trigger FSM
+    this->reg_fsm_state.set(PRELOAD);
+    this->reg_busy.set(1);
+    this->tcdm_block_total = this->get_preload_access_block_number();
+    this->fsm_counter      = 0;
+    this->fsm_timestamp    = 0;
+    this->timer_start      = this->time.get_time();
+    this->cycle_start      = this->clock.get_cycles();
+    this->event_enqueue(this->fsm_event, 1);
+}
+
+//SOFT_CLEAR write: 0 full clear, 1 clear engine state only, 2 clear regfile+queue only
+void LightRedmule::soft_clear(uint32_t value)
+{
+    if ((value == 0) || (value == 2)) {
+        //Clear job-offload state machine, job queue, ID counters, and buffered
+        //job-dependent config (regfile)
+        this->job_state      = 0;
+        this->job_pending     = 0;
+        this->cxt_job_id[0]   = -1;
+        this->cxt_job_id[1]   = -1;
+        this->running_job_id  = -1;
+        this->cxt_cfg_ptr     = 0;
+        this->cxt_use_ptr     = 0;
+        this->job_id_counter  = 0;
+        for (int i = 0; i < 2; i++) {
+            this->cxt_m_size[i]       = 0;
+            this->cxt_n_size[i]       = 0;
+            this->cxt_k_size[i]       = 0;
+            this->cxt_x_addr[i]       = 0;
+            this->cxt_w_addr[i]       = 0;
+            this->cxt_y_addr[i]       = 0;
+            this->cxt_compute_able[i] = 0;
+        }
+    }
+    if ((value == 0) || (value == 1)) {
+        //Clear engine state (compute FSM)
+        this->reg_fsm_state.set(IDLE);
+        this->reg_busy.set(0);
+        this->done.sync(false);
+    }
+}
+
+//LightRedmule register interface
 vp::IoReqStatus LightRedmule::req(vp::Block *__this, vp::IoReq *req)
 {
     LightRedmule *_this = (LightRedmule *)__this;
@@ -912,7 +1075,7 @@ vp::IoReqStatus LightRedmule::req(vp::Block *__this, vp::IoReq *req)
                         return vp::IO_REQ_OK;
                     }
 
-                    //Initilaize redmule meta data
+                    //Initialize redmule meta data
                     _this->init_redmule_meta_data();
 
                     
@@ -1003,53 +1166,33 @@ vp::IoReqStatus LightRedmule::req_v2(vp::Block *__this, vp::IoReq *req)
     uint64_t size = req->get_size();
     bool is_write = req->get_is_write();
 
-    //_this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] access (offset: 0x%x, size: 0x%x, is_write: %d, data:%x)\n", offset, size, is_write, *(uint32_t *)data);
-
     if (is_write == 1) {
         uint32_t value = *(uint32_t *)data;
         switch (offset) {
-            case 0x00: {
-                if ((_this->redmule_query == NULL) && (_this->reg_fsm_state.get() == IDLE)) {
-                    /************************
-                    *  Synchronize Trigger  *
-                    ************************/
-                    //Sanity Check
-                    _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] redmule configuration (M-N-K): %d, %d, %d. Compute able is %d\n", _this->m_size, _this->n_size, _this->k_size,_this->compute_able);
-                    if ((_this->m_size == 0)||(_this->n_size == 0)||(_this->k_size == 0))
-                    {
-                        _this->trace.fatal("[LightRedmule] INVALID redmule configuration (M-N-K): %d, %d, %d\n", _this->m_size, _this->n_size, _this->k_size);
-                        return vp::IO_REQ_OK;
+            case 0x00: { //REDMULE_TRIGGER / hwpe_commit_trigger
+                uint32_t ct = value & 0x3;
+                if (ct == 2) {
+                    //Trigger-only: start whatever is already queued, no new commit
+                    if ((_this->job_pending > 0) && (_this->reg_fsm_state.get() == IDLE)) {
+                        _this->start_next_job();
                     }
-
-                    //Initilaize redmule meta data
-                    _this->init_redmule_meta_data();
-
-                    
-
-                    //Trigger FSM
-                    _this->reg_fsm_state.set(PRELOAD);
-                    _this->reg_busy.set(1);
-                    _this->tcdm_block_total = _this->get_preload_access_block_number();
-                    _this->fsm_counter      = 0;
-                    _this->fsm_timestamp    = 0;
-                    _this->timer_start      = _this->time.get_time();
-                    _this->cycle_start      = _this->clock.get_cycles();
-                    _this->event_enqueue(_this->fsm_event, 1);
-
-                    //Save Query
-                    //_this->redmule_query = req;
+                } else if (ct == 3) {
+                    //Neither bit is 0: no-op
+                } else {
+                    //ct == 0: commit + start; ct == 1: commit only (deferred start)
+                    _this->commit(ct == 0);
                 }
                 break;
             }
             case 0x20: { //REDMULE_MCFG0_PTR
-                _this->m_size=value & 0xFFFF;
-                _this->k_size=value >> 16;
-                _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] Set mcfg_reg0 -- M size %d, Set K size %d)\n", _this->m_size,_this->k_size);
+                _this->cxt_m_size[_this->cxt_cfg_ptr] = value & 0xFFFF;
+                _this->cxt_k_size[_this->cxt_cfg_ptr] = value >> 16;
+                _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] Set mcfg_reg0 -- M size %d, Set K size %d)\n", _this->cxt_m_size[_this->cxt_cfg_ptr],_this->cxt_k_size[_this->cxt_cfg_ptr]);
                 break;
             }
             case 0x24: { //REDMULE_MCFG1_PTR
-                _this->n_size=value & 0xFFFF;
-                _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] Set mcfg_reg1 -- N size %d)\n", _this->n_size);
+                _this->cxt_n_size[_this->cxt_cfg_ptr] = value & 0xFFFF;
+                _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] Set mcfg_reg1 -- N size %d)\n", _this->cxt_n_size[_this->cxt_cfg_ptr]);
                 break;
             }
             case 0x28: { //REDMULE_MCFG2_PTR
@@ -1057,25 +1200,28 @@ vp::IoReqStatus LightRedmule::req_v2(vp::Block *__this, vp::IoReq *req)
                 break;
             }
             case 0x2C: {
-                _this->x_addr = value;
-                _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] Set X addr 0x%x)\n", _this->x_addr);
+                _this->cxt_x_addr[_this->cxt_cfg_ptr] = value;
+                _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] Set X addr 0x%x)\n", _this->cxt_x_addr[_this->cxt_cfg_ptr]);
                 break;
             }
             case 0x30: {
-                _this->w_addr = value;
-                _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] Set W addr 0x%x)\n", _this->w_addr);
+                _this->cxt_w_addr[_this->cxt_cfg_ptr] = value;
+                _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] Set W addr 0x%x)\n", _this->cxt_w_addr[_this->cxt_cfg_ptr]);
                 break;
             }
             case 0x34: {
-                _this->y_addr = value;
-                _this->z_addr = _this->y_addr;
-                _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] Set Y addr 0x%x, Set Z addr 0x%x)\n", _this->y_addr,_this->z_addr);
+                _this->cxt_y_addr[_this->cxt_cfg_ptr] = value;
+                _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] Set Y addr 0x%x)\n", _this->cxt_y_addr[_this->cxt_cfg_ptr]);
+                break;
+            }
+            case 0x14: { //REDMULE_SOFT_CLEAR
+                _this->soft_clear(value);
+                _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] SOFT_CLEAR 0x%x\n", value);
                 break;
             }
             case 0x54: {
-                _this->compute_able = _this->op_foramt_parser((value == 0x480)? 9:0); //the marith mapping between reg-if and offload-if is different... WHY?
-                _this->elem_size = (_this->compute_able < 4)? 2:1;
-                _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] marith 0x%x, compute_able 0x%x, elem_size %d)\n", value,_this->compute_able,_this->elem_size);
+                _this->cxt_compute_able[_this->cxt_cfg_ptr] = _this->op_foramt_parser((value == 0x480)? 9:0); //the marith mapping between reg-if and offload-if is different... WHY?
+                _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] marith 0x%x, compute_able 0x%x)\n", value,_this->cxt_compute_able[_this->cxt_cfg_ptr]);
                 break;
             }
             default:
@@ -1084,20 +1230,22 @@ vp::IoReqStatus LightRedmule::req_v2(vp::Block *__this, vp::IoReq *req)
     }
     else {
         switch (offset) {
-            case 0x00:
-                _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] read to INVALID address\n");
+            case 0x04: { //REDMULE_ACQUIRE
+                int32_t id = _this->acquire();
+                memcpy((void *)data, (void *)&id, size);
+                _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] ACQUIRE -> job id %d\n", id);
                 break;
-            case 0x0C: {
-                int32_t done_id_r;
-                if ((_this->redmule_query == NULL) && (_this->reg_fsm_state.get() == IDLE)) {
-                    done_id_r =  0x00;
-                    memcpy((void *)data, (void *)&done_id_r, size);
-                }
-                else {
-                    done_id_r =  0x01;
-                    memcpy((void *)data, (void *)&done_id_r, size);
-                }
-                _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] read status reg 0x%x\n",done_id_r);
+            }
+            case 0x0C: { //REDMULE_STATUS - per-slot busy bitfield (bit0 slot0, bit8 slot1)
+                uint32_t status = (_this->cxt_job_id[0] >= 0 ? 0x1 : 0) | (_this->cxt_job_id[1] >= 0 ? 0x100 : 0);
+                memcpy((void *)data, (void *)&status, size);
+                _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] read status reg 0x%x\n",status);
+                break;
+            }
+            case 0x10: { //REDMULE_RUNNING_JOB
+                uint32_t running_job = (uint32_t) _this->running_job_id;
+                memcpy((void *)data, (void *)&running_job, size);
+                _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] RUNNING_JOB -> %d\n", _this->running_job_id);
                 break;
             }
             default:
@@ -1106,68 +1254,6 @@ vp::IoReqStatus LightRedmule::req_v2(vp::Block *__this, vp::IoReq *req)
     }
     return vp::IO_REQ_OK;
 }
-
-    // if ((is_write == 0) && (offset == 32) && (_this->redmule_query == NULL) && (_this->reg_fsm_state.get() == IDLE))
-    // {
-    //     /************************
-    //     *  Synchronize Trigger  *
-    //     ************************/
-    //     //Sanity Check
-    //     _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] redmule configuration (M-N-K): %d, %d, %d\n", _this->m_size, _this->n_size, _this->k_size);
-    //     if ((_this->m_size == 0)||(_this->n_size == 0)||(_this->k_size == 0))
-    //     {
-    //         _this->trace.fatal("[LightRedmule] INVALID redmule configuration (M-N-K): %d, %d, %d\n", _this->m_size, _this->n_size, _this->k_size);
-    //         return vp::IO_REQ_OK;
-    //     }
-
-    //     //Initilaize redmule meta data
-    //     _this->init_redmule_meta_data();
-
-    //     //Trigger FSM
-    //     _this->state.set(PRELOAD);
-    //     _this->tcdm_block_total = _this->get_preload_access_block_number();
-    //     _this->fsm_counter      = 0;
-    //     _this->fsm_timestamp    = 0;
-    //     _this->timer_start      = _this->time.get_time();
-    //     _this->cycle_start      = _this->clock.get_cycles();
-    //     _this->compute_able     = 0;
-    //     _this->event_enqueue(_this->fsm_event, 1);
-
-    //     //Save Query
-    //     _this->redmule_query = req;
-    //     return vp::IO_REQ_PENDING;
-
-    // } else if ((is_write == 0) && (offset == 36) && (_this->reg_fsm_state.get() == IDLE)){
-    //     /*************************
-    //     *  Asynchronize Trigger  *
-    //     *************************/
-    //     //Sanity Check
-    //     _this->trace.msg(vp::Trace::LEVEL_TRACE,"[LightRedmule] redmule configuration (M-N-K): %d, %d, %d\n", _this->m_size, _this->n_size, _this->k_size);
-    //     if ((_this->m_size == 0)||(_this->n_size == 0)||(_this->k_size == 0))
-    //     {
-    //         _this->trace.fatal("[LightRedmule] INVALID redmule configuration (M-N-K): %d, %d, %d\n", _this->m_size, _this->n_size, _this->k_size);
-    //         return vp::IO_REQ_OK;
-    //     }
-
-    //     //Initilaize redmule meta data
-    //     _this->init_redmule_meta_data();
-
-    //     //Trigger FSM
-    //     _this->state.set(PRELOAD);
-    //     _this->tcdm_block_total = _this->get_preload_access_block_number();
-    //     _this->fsm_counter      = 0;
-    //     _this->fsm_timestamp    = 0;
-    //     _this->timer_start      = _this->time.get_time();
-    //     _this->cycle_start      = _this->clock.get_cycles();
-    //     _this->compute_able     = 0;
-    //     _this->event_enqueue(_this->fsm_event, 1);
-
-    // } else if ((is_write == 0) && (offset == 40) && (_this->redmule_query == NULL) && (_this->reg_fsm_state.get() != IDLE)){
-    //     /*************************
-    //     *  Asynchronize Waiting  *
-    //     *************************/
-    //     _this->redmule_query = req;
-    //     return vp::IO_REQ_PENDING;
 
 vp::IoReqStatus LightRedmule::send_tcdm_req()
 {
@@ -1183,6 +1269,11 @@ void LightRedmule::fsm_handler(vp::Block *__this, vp::ClockEvent *event)
     switch (_this->reg_fsm_state.get()) {
         case IDLE:
             _this->done.sync(false); //clear irq
+            //Auto-continue: start the next queued job, if any (depth-2 pipelining).
+            //Happens after done is deasserted.
+            if (_this->job_pending > 0) {
+                _this->start_next_job();
+            }
             break;
 
         case PRELOAD: {
@@ -1439,6 +1530,14 @@ void LightRedmule::fsm_handler(vp::Block *__this, vp::ClockEvent *event)
             break;
         }
         case FINISHED: {
+            //Retire the job that just finished (no-op for jobs launched via the
+            //offload/custom-instruction path, which never touches job_pending)
+            _this->cxt_job_id[_this->cxt_use_ptr] = -1;
+            _this->cxt_use_ptr = 1 - _this->cxt_use_ptr;
+            if (_this->job_pending > 0) {
+                _this->job_pending--;
+            }
+
             //Reply Stalled Query
             if (_this->redmule_query == NULL)
             {


### PR DESCRIPTION
This pull request:
- adds explicit FSM (Finite State Machine) state tracking and profiling support to the `idma` model.
- adds (minimal) state tracking and profiling support to the `light_redmule` model.
- aligns the controller interface of `light_redmule` to the real `redmule` controller based on github.com/pulp-platform/hwpe-ctrl